### PR TITLE
Add libmysqlclient-dev to depends.sh

### DIFF
--- a/setup/depends.sh
+++ b/setup/depends.sh
@@ -23,7 +23,7 @@ echo "[*] Installing pip/gcc ..."
 apt-get install python-pip python-dev build-essential
 
 echo "[*] Installing packages ..."
-apt-get install mysql-server memcached libmemcached-dev python-mysqldb python-mysqldb-dbg python-pycurl python-recaptcha zlib1g-dev
+apt-get install mysql-server memcached libmemcached-dev python-mysqldb python-mysqldb-dbg python-pycurl python-recaptcha zlib1g-dev libmysqlclient-dev
 
 echo "[*] Installing python libs ..."
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
Fixes error while `pip install mysql-python` is running. Error was -
`EnvironmentError: mysql_config not found` while installing on a vanilla
Ubuntu 14.04.1 Server.