### PR TITLE
Fixed DatabaseConnection so it won't crash when db is set to SQLite

### DIFF
--- a/libs/DatabaseConnection.py
+++ b/libs/DatabaseConnection.py
@@ -58,7 +58,7 @@ class DatabaseConnection(object):
         SQLite connection string, always save db file to cwd, or in-memory
         '''
         logging.debug("Configured to use SQLite for a database")
-        db_name = os.path.basename(self.config.get("Database", 'name'))
+        db_name = self.database
         if not len(db_name):
             db_name = 'rtb'
         return 'sqlite:///%s.db' % db_name


### PR DESCRIPTION
The code was trying to get the DB name by calling self.config which didn't exist (anymore?) and crashing while dialect==sqlite.
Changed to use the database name passed into the DatabaseConnection object.

Could still call os.path.basename(self.database) but it would be redundant as it would be unlikely for a user to provide a "path" as the database name in the config file.