### PR TITLE
Bugfix for adding source_code to the market

### DIFF
--- a/handlers/AdminHandlers/AdminGameHandlers.py
+++ b/handlers/AdminHandlers/AdminGameHandlers.py
@@ -160,7 +160,7 @@ class AdminSourceCodeMarketHandler(BaseHandler):
             self.render("public/404.html")
 
     def add_source_code(self):
-        box = Box.by_uuid(self.get_argument('box_uuid'), '')
+        box = Box.by_uuid(self.get_argument('box_uuid'))
         if box is not None:
             file_count = len(self.request.files['source_archive'])
             if not 'source_archive' in self.request.files and 0 < file_count:


### PR DESCRIPTION
Here's the error I was encountering that this fixed:

        Traceback (most recent call last):
      File "/usr/local/lib/python2.7/dist-packages/tornado/web.py", line 1346, in _execute
        result = method(*self.path_args, **self.path_kwargs)
      File "/opt/RootTheBox/libs/SecurityDecorators.py", line 63, in wrapper
        return method(self, *args, **kwargs)
      File "/opt/RootTheBox/libs/SecurityDecorators.py", line 38, in wrapper
        return method(self, *args, **kwargs)
      File "/opt/RootTheBox/libs/SecurityDecorators.py", line 93, in wrapper
        return method(self, *args, **kwargs)
      File "/opt/RootTheBox/handlers/AdminHandlers/AdminGameHandlers.py", line 154, in post
        uri[args[0]]()
      File "/opt/RootTheBox/handlers/AdminHandlers/AdminGameHandlers.py", line 163, in add_source_code
        box = Box.by_uuid(self.get_argument('box_uuid'), '')
    TypeError: by_uuid() takes exactly 2 arguments (3 given)

This was happening any time I tried to add source_code to the marketplace in admin/upgrades/source_code_market/add