### PR TITLE
Fixed source code buying error

### DIFF
--- a/static/js/pages/upgrades/source_code_market.js
+++ b/static/js/pages/upgrades/source_code_market.js
@@ -1,6 +1,6 @@
 $(document).ready(function() {
 
-    $("a[id^=buy-source-code-button").click(function() {
+    $("a[id^='buy-source-code-button']").click(function() {
         $("#buy-source-code-uuid").val($(this).data("uuid"));
         $("#buy-source-code-dialog").text(
             "Are you sure you want to buy this code for $" + $(this).data("price") + "?"
@@ -11,7 +11,7 @@ $(document).ready(function() {
         $("#buy-source-code-form").submit();
     });
 
-    $("a[id^=download-source-code-button").click(function() {
+    $("a[id^='download-source-code-button']").click(function() {
         window.open('/source_code_market/download?uuid=' + $(this).data("uuid"), '_newtab');
     });
 


### PR DESCRIPTION
Error on jQuery selectors prevented players to purchase and download source codes on Source Code Market.
Tested on Iceweasel 31.8.0 and Safari 9.0.1