### PR TITLE
Fixed XML import error

### DIFF
--- a/handlers/AdminHandlers/AdminGameHandlers.py
+++ b/handlers/AdminHandlers/AdminGameHandlers.py
@@ -40,7 +40,7 @@ from libs.ValidationError import ValidationError
 from libs.ConfigHelpers import save_config
 from handlers.BaseHandlers import BaseHandler
 from string import printable
-
+from setup.xmlsetup import import_xml
 
 class AdminGameHandler(BaseHandler):
 


### PR DESCRIPTION
The XML import feature from the administrator interface could return a 404 error.