### PR TITLE
add python 3 support

### DIFF
--- a/libs/ConfigHelpers.py
+++ b/libs/ConfigHelpers.py
@@ -17,8 +17,20 @@ def save_config():
             if 'rootthebox.py' in group.lower() or group == '':
                 continue
             fp.write("\n# [ %s ]\n" % group.title())
-            for key, value in options.group_dict(group).iteritems():
-                if isinstance(value, basestring):
+            try:
+                # python2
+                opt = options.group_dict(group).iteritems()
+            except AttributeError:
+                # python3
+                opt = options.group_dict(group).items()
+            for key, value in opt:
+                try:
+                    # python2
+                    value_type = basestring
+                except NameError:
+                    # python 3
+                    value_type = str
+                if isinstance(value, value_type):
                     # Str/Unicode needs to have quotes
                     fp.write(u'%s = "%s"\n' % (key, value))
                 else:

--- a/rootthebox.py
+++ b/rootthebox.py
@@ -282,11 +282,16 @@ define("memcached_port",
 
 
 # Game Settings
+try:
+    game_type = basestring
+except NameError:
+    game_type = str
+
 define("game_name",
        default="Root the Box",
        group="game",
        help="the name of the current game",
-       type=basestring)
+       type=game_type)
 
 define("restrict_registration",
        default=False,

--- a/rootthebox.py
+++ b/rootthebox.py
@@ -283,8 +283,10 @@ define("memcached_port",
 
 # Game Settings
 try:
+    # python2
     game_type = basestring
 except NameError:
+    # python 3
     game_type = str
 
 define("game_name",


### PR DESCRIPTION
add python 3 support `rootthebox.py` and its dependency `libs/ConfigHelpers.py`.

So it's support both python 2 and python 3.