### PR TITLE
Allow admin to disable the "Administrative IPs" protection

### DIFF
--- a/libs/SecurityDecorators.py
+++ b/libs/SecurityDecorators.py
@@ -59,7 +59,7 @@ def restrict_ip_address(method):
 
     @functools.wraps(method)
     def wrapper(self, *args, **kwargs):
-        if self.request.remote_ip in self.application.settings['admin_ips']:
+        if len(self.application.settings['admin_ips']) == 0 or self.request.remote_ip in self.application.settings['admin_ips']:
             return method(self, *args, **kwargs)
         else:
             logging.warn("Attempted unauthorized access from %s to %s" % (

--- a/rootthebox.py
+++ b/rootthebox.py
@@ -189,7 +189,7 @@ define("admin_ips",
        multiple=True,
        default=['127.0.0.1', '::1'],
        group="server",
-       help="whitelist of ip addresses that can access the admin ui")
+       help="whitelist of ip addresses that can access the admin ui (use empty list to allow all ip addresses)")
 
 # Application Settings
 define("debug",


### PR DESCRIPTION
Allow the admin_ips to be defined as an empty list, which translates into "allow all" access to administration APIs / Views