### PR TITLE
Add an option for single submission form for all static flags related to a box

### DIFF
--- a/handlers/AdminHandlers/AdminGameObjectHandlers.py
+++ b/handlers/AdminHandlers/AdminGameObjectHandlers.py
@@ -507,6 +507,13 @@ class AdminEditHandler(BaseHandler):
                     box.name, box.difficulty, difficulty,
                 ))
                 box.difficulty = difficulty
+            # Flag submission type
+            flag_submission_type = self.get_argument('flag_submission_type', '')
+            if flag_submission_type is not None and flag_submission_type != box.flag_submission_type:
+                logging.info("Updated %s's flag submission type %s -> %s" % (
+                    box.name, box.flag_submission_type, flag_submission_type
+                ))
+                box.flag_submission_type = flag_submission_type
             # Avatar
             avatar_select = self.get_argument('box_avatar_select', '')
             if avatar_select and len(avatar_select) > 0:

--- a/handlers/AdminHandlers/AdminGameObjectHandlers.py
+++ b/handlers/AdminHandlers/AdminGameObjectHandlers.py
@@ -33,7 +33,7 @@ import re
 import json
 
 from handlers.BaseHandlers import BaseHandler
-from models.Box import Box
+from models.Box import Box, FlagsSubmissionType
 from models.Corporation import Corporation
 from models.Category import Category
 from models.GameLevel import GameLevel
@@ -183,6 +183,7 @@ class AdminCreateHandler(BaseHandler):
                 box.name = self.get_argument('name', '')
                 box.description = self.get_argument('description', '')
                 box.autoformat = self.get_argument('autoformat', '') == 'true'
+                box.flag_submission_type = FlagsSubmissionType[self.get_argument('flag_submission_type','')]
                 box.difficulty = self.get_argument('difficulty', '')
                 box.operating_system = self.get_argument('operating_system', '?')
                 cat = Category.by_uuid(self.get_argument('category_uuid', ''))

--- a/handlers/MissionsHandler.py
+++ b/handlers/MissionsHandler.py
@@ -83,7 +83,7 @@ class FlagSubmissionHandler(BaseHandler):
         user = self.get_current_user()
         if flag and flag in user.team.flags:
             self.render_page_by_flag(flag)
-        elif flag is not None and (flag.game_level.type == 'none' or flag.game_level in user.team.game_levels):
+        elif flag is None or flag.game_level.type == 'none' or flag.game_level in user.team.game_levels:
             submission = ''
             if flag is not None and flag.is_file:
                 if hasattr(self.request, 'files') and 'flag' in self.request.files:

--- a/handlers/MissionsHandler.py
+++ b/handlers/MissionsHandler.py
@@ -249,7 +249,7 @@ class FlagSubmissionHandler(BaseHandler):
                 self.dbsession.add(user.team)
 
     def render_page_by_flag(self, flag, errors=[], success=[], info=[]):
-        self.render_page_by_box_id(flag.box_id)
+        self.render_page_by_box_id(flag.box_id, errors, success, info)
 
     def render_page_by_box_id(self, box_id, errors=[], success=[], info=[]):
         box = Box.by_id(box_id)

--- a/handlers/MissionsHandler.py
+++ b/handlers/MissionsHandler.py
@@ -73,20 +73,26 @@ class FlagSubmissionHandler(BaseHandler):
     @authenticated
     def post(self, *args, **kwargs):
         ''' Check validity of flag submissions '''
-        flag = Flag.by_uuid(self.get_argument('uuid', ''))
+        box_id = self.get_argument('box_id', None)
+        uuid = self.get_argument('uuid', '')
+        token = self.get_argument('token', '')
+        if(box_id is not None and token is not None):
+            flag = Flag.by_token_and_box_id(token, box_id)
+        else:
+            flag = Flag.by_uuid(uuid)
         user = self.get_current_user()
         if flag and flag in user.team.flags:
-            self.render_page(flag)
-        elif flag is not None and flag.game_level in user.team.game_levels:
+            self.render_page_by_flag(flag)
+        elif flag is None or (flag.game_level in user.team.game_levels):
             submission = ''
-            if flag.is_file:
+            if flag is not None and flag.is_file:
                 if hasattr(self.request, 'files') and 'flag' in self.request.files:
                     submission = self.request.files['flag'][0]['body']
             else:
                 submission = self.get_argument('token', '')
-            old_reward = flag.value
+            old_reward = flag.value if flag is not None else 0
 
-            if self.attempt_capture(flag, submission):
+            if flag is not None and self.attempt_capture(flag, submission):
                 self.add_content_policy('script', "'unsafe-eval'")
                 if self.config.story_mode:
                     self.render('missions/captured.html',
@@ -94,14 +100,14 @@ class FlagSubmissionHandler(BaseHandler):
                                 reward=old_reward)
                 else:
                     success = self.success_capture(flag)
-                    self.render_page(flag, success=success)
+                    self.render_page_by_flag(flag, success=success)
             else:
-                if Penalty.by_token_count(flag, user.team, submission) == 0:
+                if flag is None or Penalty.by_token_count(flag, user.team, submission) == 0:
                     if self.config.teams:
                         teamval = "team's "
                     else:
                         teamval = ""
-                    penalty = self.failed_capture(flag, submission)
+                    penalty = self.failed_capture(flag, submission) if flag is not None else 0
                     penalty_dialog = "Sorry - Try Again"
                     if penalty:
                         if self.config.banking:
@@ -112,13 +118,16 @@ class FlagSubmissionHandler(BaseHandler):
                             else:
                                 point = " points have"
                             penalty_dialog = str(penalty) + point + " been deducted from your " + teamval + "score."
-                    self.render_page(flag, errors=[penalty_dialog])
+                    if flag is None:
+                        self.render_page_by_box_id(box_id, errors=[penalty_dialog])
+                    else:
+                        self.render_page_by_flag(flag, errors=[penalty_dialog])
                 else:
                     if self.config.teams:
                         teamdup = " by your team.  Try Again"
                     else:
                         teamdup = " by you.  Try Again"
-                    self.render_page(flag, info=["Duplicate submission - this answer has already been attempted" + teamdup])
+                    self.render_page_by_flag(flag, info=["Duplicate submission - this answer has already been attempted" + teamdup])
         else:
             self.render('public/404.html')
 
@@ -239,10 +248,16 @@ class FlagSubmissionHandler(BaseHandler):
                 user.team.game_levels.append(next_level)
                 self.dbsession.add(user.team)
 
-    def render_page(self, flag, errors=[], success=[], info=[]):
+    def render_page_by_flag(self, flag, errors=[], success=[], info=[]):
+        self.render_page_by_box_id(flag.box_id)
+
+    def render_page_by_box_id(self, box_id, errors=[], success=[], info=[]):
+        box = Box.by_id(box_id)
+        self.render_page_by_box(box, errors, success, info)
+
+    def render_page_by_box(self, box, errors=[], success=[], info=[]):
         ''' Wrapper to .render() to avoid duplicate code '''
         user = self.get_current_user()
-        box = Box.by_id(flag.box_id)
         self.render('missions/box.html',
                     box=box,
                     team=user.team,

--- a/models/Box.py
+++ b/models/Box.py
@@ -45,9 +45,9 @@ from PIL import Image
 from resizeimage import resizeimage
 import enum
 
-class FlagsSubmissionType(enum.Enum):
-    CLASSIC = 0
-    SINGLE_SUBMISSION_BOX = 1
+class FlagsSubmissionType(str, enum.Enum):
+    CLASSIC = 'CLASSIC'
+    SINGLE_SUBMISSION_BOX = 'SINGLE_SUBMISSION_BOX'
 
 class Box(DatabaseObject):
     ''' Box definition '''

--- a/models/Flag.py
+++ b/models/Flag.py
@@ -113,6 +113,11 @@ class Flag(DatabaseObject):
         return dbsession.query(cls).filter_by(_token=unicode(token)).first()
 
     @classmethod
+    def by_token_and_box_id(cls, token, box_id):
+        ''' Return and object based on a token '''
+        return dbsession.query(cls).filter_by(_token=unicode(token), box_id = box_id).first()
+
+    @classmethod
     def by_type(cls, _type):
         ''' Return and object based on a token '''
         return dbsession.query(cls).filter_by(_type=unicode(_type)).all()
@@ -290,6 +295,14 @@ class Flag(DatabaseObject):
                 self.lock_id = abs(int(value))
         except ValueError:
             self.lock_id = None
+
+    @property
+    def is_text(self):
+        return self._type == FLAG_REGEX or self._type == FLAG_STATIC
+
+    @property
+    def is_static(self):
+        return self._type == FLAG_STATIC
 
     @property
     def is_file(self):

--- a/setup/dbupdate.sql
+++ b/setup/dbupdate.sql
@@ -75,6 +75,9 @@ ADD CONSTRAINT `box_ibfk_3`
   ON DELETE NO ACTION
   ON UPDATE NO ACTION;
 
+ALTER TABLE `rootthebox`.`box` 
+ADD COLUMN `flag_submission_type` enum('CLASSIC','SINGLE_SUBMISSION_BOX') DEFAULT 'CLASSIC' AFTER `garbage`;
+  
 CREATE TABLE `flag_choice` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `created` datetime DEFAULT NULL,

--- a/static/js/pages/admin/create/box.js
+++ b/static/js/pages/admin/create/box.js
@@ -46,6 +46,7 @@ $(document).ready(function() {
     $("#operating-system").popover({placement:'right', trigger:'hover'});
     $("#description").popover({placement:'right', trigger:'hover'});
     $("#autoformat-button").popover({placement:'right', trigger:'hover'});
+    $("#flag-submission-type-button").popover({placement:'right', trigger:'hover'});
     $("#difficulty").popover({placement:'right', trigger:'hover'});
 
     /* Avatar */

--- a/static/js/pages/admin/create/box.js
+++ b/static/js/pages/admin/create/box.js
@@ -1,5 +1,9 @@
 $(document).ready(function() {
 
+    $(function () {
+        $('[data-toggle="tooltip"]').tooltip()
+    })
+
     /* Button callbacks */
     $(".osbutton").click(function() {
         $("#operating_system").val($(this).data("os"));
@@ -18,6 +22,21 @@ $(document).ready(function() {
         $("#autoformat-disable-icon").addClass("fa-check-square-o");
         $("#autoformat-enable-icon").removeClass("fa-check-square-o");
         $("#autoformat-enable-icon").addClass("fa-square-o");
+    });
+
+    $("#flag-submission-type-classic").click(function() {
+        $("#flag_submission_type").val("CLASSIC");
+        $("#flag-submission-type-classic-icon").removeClass("fa-square-o");
+        $("#flag-submission-type-classic-icon").addClass("fa-check-square-o");
+        $("#flag-submission-type-single-boxe-icon").removeClass("fa-check-square-o");
+        $("#flag-submission-type-single-box-icon").addClass("fa-square-o");
+    });
+    $("#flag-submission-type-single-box").click(function() {
+        $("#flag_submission_type").val("SINGLE_SUBMISSION_BOX");
+        $("#flag-submission-type-classic-icon").removeClass("fa-check-square-o");
+        $("#flag-submission-type-classic-icon").addClass("fa-square-o");
+        $("#flag-submission-type-single-box-icon").removeClass("fa-square-o");
+        $("#flag-submission-type-single-box-icon").addClass("fa-check-square-o");
     });
 
     /* Popovers */

--- a/static/js/pages/admin/view/game_objects.js
+++ b/static/js/pages/admin/view/game_objects.js
@@ -37,6 +37,11 @@ function getDetails(obj, uuid) {
                 }
             } else if (obj === "box" && key === "corporation") {
                 $('#edit-box-corporation option[value=' + value + ']').prop('selected',true);
+            } else if (obj === "box" && key === "flag_submission_type") {
+                if(value == "CLASSIC")
+                    $('#box-flag-submission-type-classic').click();
+                else if(value == "SINGLE_SUBMISSION_BOX")
+                    $('#box-flag-submission-type-single-box').click();
             } else if (obj === "flag" && key === "lock_uuid") {
                 if (value.length > 0) {
                     $('#edit-flag-lock option[value=' + value + ']').prop('selected',true);
@@ -188,6 +193,21 @@ $(document).ready(function() {
 
     $("a[id^=delete-ip-address-button]").click(function() {
         $("#delete-ip-address-uuid").val($(this).data("uuid"));
+    });
+
+    $("#box-flag-submission-type-classic").click(function() {
+        $("#box-flag_submission_type").val("CLASSIC");
+        $("#box-flag-submission-type-classic-icon").removeClass("fa-square-o");
+        $("#box-flag-submission-type-classic-icon").addClass("fa-check-square-o");
+        $("#box-flag-submission-type-single-boxe-icon").removeClass("fa-check-square-o");
+        $("#box-flag-submission-type-single-box-icon").addClass("fa-square-o");
+    });
+    $("#box-flag-submission-type-single-box").click(function() {
+        $("#box-flag_submission_type").val("SINGLE_SUBMISSION_BOX");
+        $("#box-flag-submission-type-classic-icon").removeClass("fa-check-square-o");
+        $("#box-flag-submission-type-classic-icon").addClass("fa-square-o");
+        $("#box-flag-submission-type-single-box-icon").removeClass("fa-square-o");
+        $("#box-flag-submission-type-single-box-icon").addClass("fa-check-square-o");
     });
 
     /* Flag */

--- a/templates/admin/create/box.html
+++ b/templates/admin/create/box.html
@@ -191,16 +191,12 @@
                     <div id="flag-submission-type-button" class="btn-group" data-toggle="buttons-radio"
                          rel="popover"
                          data-original-title="Flag Submission Type"
-                         data-content="How should the flag submission box be displayed?">
-                        <button id="flag-submission-type-classic" type="button" class="btn btn-primary"
-                                data-toggle="tooltip"
-                                title="Classic: list all flags and allow user to submit each">
+                         data-content="Modifies the way flag submission are made. Choose 'Classic' to have the user choose the flag before submitting, or 'Single Box' to have a single box and let the system automatically detect the flag used (Note: no penalties will be applied in 'Single Box' mode)">
+                        <button id="flag-submission-type-classic" type="button" class="btn btn-primary">
                             <i id="flag-submission-type-classic-icon" class="fa fa-fw fa-check-square-o"></i>
                             Classic
                         </button>
-                        <button id="flag-submission-type-single-box" type="button" class="btn btn-primary"
-                                data-toggle="tooltip"
-                                title="Use a single submission box for all *static* flags. Matching flag will be detected automatically. No penalties will be applied">
+                        <button id="flag-submission-type-single-box" type="button" class="btn btn-primary">
                             <i id="flag-submission-type-single-box-icon" class="fa fa-fw fa-square-o"></i>
                             Single Box
                         </button>

--- a/templates/admin/create/box.html
+++ b/templates/admin/create/box.html
@@ -183,6 +183,31 @@
                 </div>
             </div>
             <div class="control-group">
+                <label class="control-label" for="flag_submission_type">
+                    Flag Submission Type
+                </label>
+                <div class="controls">
+                    <input id="flag_submission_type" name="flag_submission_type" type="hidden" value="CLASSIC" />
+                    <div id="flag-submission-type-button" class="btn-group" data-toggle="buttons-radio"
+                         rel="popover"
+                         data-original-title="Flag Submission Type"
+                         data-content="How should the flag submission box be displayed?">
+                        <button id="flag-submission-type-classic" type="button" class="btn btn-primary"
+                                data-toggle="tooltip"
+                                title="Classic: list all flags and allow user to submit each">
+                            <i id="flag-submission-type-classic-icon" class="fa fa-fw fa-check-square-o"></i>
+                            Classic
+                        </button>
+                        <button id="flag-submission-type-single-box" type="button" class="btn btn-primary"
+                                data-toggle="tooltip"
+                                title="Use a single submission box for all *static* flags. Matching flag will be detected automatically. No penalties will be applied">
+                            <i id="flag-submission-type-single-box-icon" class="fa fa-fw fa-square-o"></i>
+                            Single Box
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <div class="control-group">
                 <label class="control-label" for="difficulty">Difficulty</label>
                 <div class="controls">
                     <input id="difficulty" name="difficulty" maxlength="16" type="text" placeholder="Difficulty"

--- a/templates/admin/view/game_objects.html
+++ b/templates/admin/view/game_objects.html
@@ -176,6 +176,24 @@
                     </div>
                 </div>
                 <div class="control-group">
+                    <label class="control-label" for="flag_submission_type">
+                        Flag Submission Type
+                    </label>
+                    <div class="controls">
+                        <input id="box-flag_submission_type" name="flag_submission_type" type="hidden" value="CLASSIC" />
+                        <div id="box-flag-submission-type-button" class="btn-group" data-toggle="buttons-radio">
+                            <button id="box-flag-submission-type-classic" type="button" class="btn btn-primary">
+                                <i id="box-flag-submission-type-classic-icon" class="fa fa-fw fa-square-o"></i>
+                                Classic
+                            </button>
+                            <button id="box-flag-submission-type-single-box" type="button" class="btn btn-primary">
+                                <i id="box-flag-submission-type-single-box-icon" class="fa fa-fw fa-square-o"></i>
+                                Single Box
+                            </button>
+                        </div>
+                    </div>
+                </div>
+                <div class="control-group">
                     <label class="control-label" for="box_avatar">Avatar</label>
                     <div class="controls">
                         <a id="uploadbutton" class="btn btn-primary" href="#">Upload</a>

--- a/templates/missions/box.html
+++ b/templates/missions/box.html
@@ -13,6 +13,7 @@
 {% from models.Flag import FLAG_FILE %}
 {% from models.Flag import FLAG_CHOICE %}
 {% from models.FlagChoice import FlagChoice %}
+{% from models.Box import FlagsSubmissionType %}
 {% from handlers.MaterialsHandler import has_materials %}
 {% from tornado.options import options %}
     <!-- Submit text flag -->
@@ -209,6 +210,24 @@
             </div>
             {% end %}
         {% end %}
+        {% if box.flag_submission_type == FlagsSubmissionType.SINGLE_SUBMISSION_BOX %}
+        <div id="capture-text-flag-box" class="well">
+            <form id="capture-text-flag-box-form" class="form-horizontal" method="post" action="/user/missions/capture">
+                {% raw xsrf_form_html() %}
+                <input id="capture-text-flag-box-box-id" name="box_id" value="{{ box.id }}" type="hidden" />
+                <h4>Submit a Flag</h4>
+                <div class="control-group">
+                    <label class="control-label" for="capture-text-flag-box-token">Flag</label>
+                    <div class="controls">
+                        <input autofocus required id="capture-text-flag-box-token" name="token" type="text" placeholder="Flag" autocomplete="off" size="70" />
+                        <button id="capture-text-flag-box-submit" class="btn btn-primary" type="submit">
+                            Submit
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+        {% end %}
         <div class="well">
             <table class="table table-hover">
                 <caption><h4> - Flags - </h4></caption>
@@ -276,11 +295,13 @@
                                         <td class="shortcolumn successtext" style="text-align: right;"><i class="fa fa-check-circle"></i></td>
                                     {% else %}         
                                         <td class="shortcolumn">
+                                            {% if box.flag_submission_type != FlagsSubmissionType.SINGLE_SUBMISSION_BOX or not flag.is_static %}
                                             <a id="capture-{% if flag.is_file %}file{% elif flag.type == FLAG_CHOICE %}choice{% else %}text{%end%}-flag-button{{ index }}" class="btn btn-mini" data-toggle="modal" href="#capture-{% if flag.is_file %}file{% elif flag.type == FLAG_CHOICE %}choice{% else %}text{% end %}-flag-modal" 
                                             data-uuid="{{ flag.uuid }}" data-choices='{{ str(flag.choicelist()) }}'>
                                                 <i class="fa fa-flag"></i>
                                                 Submit
                                             </a>
+                                            {% end %}
                                         </td>
                                     {% end %}
                                 {% end %}

--- a/templates/public/about.html
+++ b/templates/public/about.html
@@ -48,7 +48,7 @@
                         <tr>
                             <td><h3>Und3rf10w</h3></td>
                             <td><h3>sporky</h3></td>
-                            <td><h3></h3></td>
+                            <td><h3>shshzi</h3></td>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
Add an option for single submission form for all static flags related to a box (some limitations apply)
Useful when you have a box / challenge with multiple flags, and you really don't have a good way of numbering them (they have no additional description or any other useful information, they are just there to be found)

Fixed some bugs with import / export of XML (empty corp name threw exception, export of avatar was broken).
