### PR TITLE
python2 enum error fixed

### DIFF
--- a/setup/python2-depends.sh
+++ b/setup/python2-depends.sh
@@ -27,4 +27,4 @@ pip2 install nose --upgrade
 pip2 install future --upgrade
 pip2 install python-resize-image --upgrade
 pip2 install alembic --upgrade
-pip2 isntall enum34 --upgrade
+pip2 install enum34 --upgrade


### PR DESCRIPTION
There was an error while launching RootTheBox due to the enum support on python 2.7
So, i added pip2 install enum34 --upgrade to fix that problem
Sorry for not creating the branches, but it is just simple fix so thought would not needed