### PR TITLE
Add GDPR Policy URL to registration page and footer

### DIFF
--- a/locale/de_DE.csv
+++ b/locale/de_DE.csv
@@ -288,6 +288,7 @@ Game Materials,Spielmaterialien
 Game Name,Spielname
 Game Progress,Spielfortschritt
 Garbage File,Mülleimer
+GDPR Policy,Datenschutz Richtlinie
 Get help with,Holen Sie sich Hilfe bei
 Get your registration token from reception,Holen Sie sich Ihren Registrierungs-Token an der Rezeption
 Glitch in the Matrix,Glitch in der Matrix
@@ -302,6 +303,7 @@ Hints Taken,Genutzte Hinweise
 History,Historie
 Home,Startseite
 How should the next level unlock?,Wie soll das nächste Level freigeschaltet werden?
+I accept the,Ich akzeptiere die 
 "If the flag selection is left empty, the hint will be considered a Box Hint.","Wenn die Flaggen-Auswahl leer gelassen wird, wird der Hinweis berücksichtigt"
 "If this option is disabled, there is no cost for submitting incorrect flags.","Wenn diese Option deaktiviert ist, fallen keine Kosten für die Übermittlung falscher Flaggen an."
 Import File,Datei importieren

--- a/locale/de_DE.csv
+++ b/locale/de_DE.csv
@@ -288,7 +288,6 @@ Game Materials,Spielmaterialien
 Game Name,Spielname
 Game Progress,Spielfortschritt
 Garbage File,Mülleimer
-GDPR Policy,Datenschutz Richtlinie
 Get help with,Holen Sie sich Hilfe bei
 Get your registration token from reception,Holen Sie sich Ihren Registrierungs-Token an der Rezeption
 Glitch in the Matrix,Glitch in der Matrix
@@ -461,6 +460,7 @@ points,Punkte
 Previous Bribes,Vorherige Bestechungsgelder
 Price,Preis
 Private,Privatgelände
+Privacy Policy,Datenschutz Richtlinie
 Programming,Programmierung
 Provide the code used to join an existing team.  Visible to other team members on their home page.,"Geben Sie den Code an, mit dem Sie einem vorhandenen Team beitreten. Sichtbar für andere Teammitglieder auf ihrer Homepage."
 Public,Öffentlichkeit

--- a/rootthebox.py
+++ b/rootthebox.py
@@ -439,10 +439,10 @@ define(
 )
 
 define(
-    "gdpr_link",
+    "privacy_policy_link",
     default=False,
     group="game",
-    help="Link to the GDPR Page",
+    help="Link to the privacy policy",
     type=game_type
 )
 

--- a/rootthebox.py
+++ b/rootthebox.py
@@ -439,6 +439,14 @@ define(
 )
 
 define(
+    "gdpr_link",
+    default=False,
+    group="game",
+    help="Link to the GDPR Page",
+    type=game_type
+)
+
+define(
     "story_character",
     default="/static/images/morris.jpg",
     group="game",

--- a/templates/main.html
+++ b/templates/main.html
@@ -36,7 +36,7 @@
             {% from tornado.options import options %}
             <hr style="margin-bottom: -1px;">
             <div class="navbar-inner footernav">
-                Powered by <a href="https://github.com/moloch--/RootTheBox" target="_blank">Root the Box</a> &copy; {{ datetime.date.today().year }} {% if options.gdpr_link %}; <a href="{{ options.gdpr_link }}">{{ _("GDPR Policy") }}</a>{% end%}
+                Powered by <a href="https://github.com/moloch--/RootTheBox" target="_blank">Root the Box</a> &copy; {{ datetime.date.today().year }}{% if options.privacy_policy_link %} ; <a href="{{ options.privacy_policy_link }}">{{ _("Privacy Policy") }}</a>{% end%}
                 <span style="float:right; padding-right: 5px;">{% raw options.org_footer %}</span>
             </div>
          </footer>

--- a/templates/main.html
+++ b/templates/main.html
@@ -36,7 +36,7 @@
             {% from tornado.options import options %}
             <hr style="margin-bottom: -1px;">
             <div class="navbar-inner footernav">
-                Powered by <a href="https://github.com/moloch--/RootTheBox" target="_blank">Root the Box</a> &copy; {{ datetime.date.today().year }}{% if options.privacy_policy_link %} ; <a href="{{ options.privacy_policy_link }}">{{ _("Privacy Policy") }}</a>{% end%}
+                Powered by <a href="https://github.com/moloch--/RootTheBox" target="_blank">Root the Box</a> &copy; {{ datetime.date.today().year }}{% if options.privacy_policy_link %} — <a href="{{ options.privacy_policy_link }}">{{ _("Privacy Policy") }}</a>{% end%}
                 <span style="float:right; padding-right: 5px;">{% raw options.org_footer %}</span>
             </div>
          </footer>

--- a/templates/main.html
+++ b/templates/main.html
@@ -36,7 +36,7 @@
             {% from tornado.options import options %}
             <hr style="margin-bottom: -1px;">
             <div class="navbar-inner footernav">
-                Powered by <a href="https://github.com/moloch--/RootTheBox" target="_blank">Root the Box</a> &copy; {{ datetime.date.today().year }}
+                Powered by <a href="https://github.com/moloch--/RootTheBox" target="_blank">Root the Box</a> &copy; {{ datetime.date.today().year }} {% if options.gdpr_link %}; <a href="{{ options.gdpr_link }}">{{ _("GDPR Policy") }}</a>{% end%}
                 <span style="float:right; padding-right: 5px;">{% raw options.org_footer %}</span>
             </div>
          </footer>

--- a/templates/public/registration.html
+++ b/templates/public/registration.html
@@ -227,11 +227,11 @@
                         </div>
                     </div>
                 {% end %}
-                {% if options.gdpr_link %}
+                {% if options.privacy_policy_link %}
                     <div class="control-group">
-                        <label class="control-label" for="gdpr_accept">{{ _("I accept the") }} <a href="{{ options.gdpr_link }}">{{ _("GDPR Policy") }}</a></label>
+                        <label class="control-label" for="privacy_policy_accept">{{ _("I accept the") }} <a href="{{ options.privacy_policy_link }}">{{ _("Privacy Policy") }}</a></label>
                         <div class="controls">
-                            <input required id="gdpr_accept" name="gdpr_accept" type="checkbox" />
+                            <input required id="privacy_policy_accept" name="privacy_policy_accept" type="checkbox" />
                         </div>
                     </div>
                 {% end %}

--- a/templates/public/registration.html
+++ b/templates/public/registration.html
@@ -227,6 +227,14 @@
                         </div>
                     </div>
                 {% end %}
+                {% if options.gdpr_link %}
+                    <div class="control-group">
+                        <label class="control-label" for="gdpr_accept">{{ _("I accept the") }} <a href="{{ options.gdpr_link }}">{{ _("GDPR Policy") }}</a></label>
+                        <div class="controls">
+                            <input required id="gdpr_accept" name="gdpr_accept" type="checkbox" />
+                        </div>
+                    </div>
+                {% end %}
                 <br />
                 <div class="control-group">
                     <div class="controls">


### PR DESCRIPTION
* Adds a configuration option that allows the admin to set a URL to their GDPR Policy
* If the URL is set, a link to the GDPR Policy is added to the footer
* If the URL is set, accepting the GDPR Policy is required on registration

![grafik](https://user-images.githubusercontent.com/1331699/73741807-4d1bac80-474b-11ea-9005-29894478a1bb.png)
