### PR TITLE
Identicons #335

### DIFF
--- a/files/avatars/user/README.md
+++ b/files/avatars/user/README.md
@@ -1,3 +1,3 @@
 User Avatars
 =============
-Admin provided User Avatars can be placed in this directory.  w500 x h250, 'png', 'jpeg', 'gif', 'bmp'
+Admin provided User Avatars can be placed in this directory.  w500 x h250, 'png', 'jpeg', 'gif', 'bmp', 'svg'

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -151,7 +151,7 @@ urls = [
         {"path": "static/"},
     ),
     (
-        r"/avatars/(.*\.(png|jpeg|jpg|gif|bmp))",
+        r"/avatars/(.*\.(png|jpeg|jpg|gif|bmp|svg))",
         StaticFileHandler,
         {"path": "files/avatars/"},
     ),

--- a/libs/Identicon.py
+++ b/libs/Identicon.py
@@ -1,0 +1,44 @@
+# source: https://github.com/evuez/svg-identicon
+# Modified for 2 x 1 ratio - RootTheBox
+from os import path
+from hashlib import md5
+from tornado.options import options
+
+
+def _svg(width, height, body, color):
+    return """<?xml version="1.0"?>
+    <svg width="{w}" height="{h}"
+        viewBox="0 0 {w} {h}"
+        viewport-fill="red"
+        xmlns="http://www.w3.org/2000/svg">
+    <rect x="0" y="0" width="{w}" height="{h}" fill="{color}"/>
+    {body}
+    </svg>""".format(
+        w=width, h=height, body=body, color=color
+    )
+
+
+def _rect(x, y, width, height, color, stroke, stroke_weight):
+    return '<rect x="{}" y="{}" width="{}" height="{}" fill="{}" stroke="{}" stroke-width="{}"/>'.format(
+        x, y, width, height, color, stroke, stroke_weight
+    )
+
+
+def identicon(str_, size, background="#f0f0f0"):
+    digest = int(md5(str_.encode("utf-8")).hexdigest(), 16)
+    color = "#{:06x}".format(digest & 0xFFFFFF)
+    stroke_weight = 0.02
+    digest, body = digest >> 24, ""
+    x = y = 0
+    for t in range(size ** 2):
+        if digest & 1:
+            body += _rect(x, y, 1, 1, color, background, stroke_weight)
+            body += _rect(size * 2 - x - 1, y, 1, 1, color, background, stroke_weight)
+        digest, y = digest >> 1, y + 1
+        x, y = (x + 1, 0) if y == size else (x, y)
+    image_data = _svg(size * 2, size, body, background)
+    avatar = "upload/%s.svg" % str(digest)
+    file_path = path.join(options.avatar_dir, avatar)
+    with open(file_path, "w") as fp:
+        fp.write(image_data)
+    return avatar

--- a/models/Team.py
+++ b/models/Team.py
@@ -218,7 +218,8 @@ class Team(DatabaseObject):
 
             else:
                 raise ValidationError(
-                    "Invalid image format, avatar must be: %s" % (" ".join(IMG_FORMATS))
+                    "Invalid image format, avatar must be: %s"
+                    % (", ".join(IMG_FORMATS))
                 )
         else:
             raise ValidationError(

--- a/models/User.py
+++ b/models/User.py
@@ -298,7 +298,8 @@ class User(DatabaseObject):
                     raise ValidationError(e)
             else:
                 raise ValidationError(
-                    "Invalid image format, avatar must be: %s" % (" ".join(IMG_FORMATS))
+                    "Invalid image format, avatar must be: %s"
+                    % (", ".join(IMG_FORMATS))
                 )
         else:
             raise ValidationError(

--- a/rootthebox.py
+++ b/rootthebox.py
@@ -198,7 +198,9 @@ def options_parse_environment():
                 value = config
             value = set_type(value, options[item])
             if isinstance(value, type(options[item])):
-                logging.info("Environment Configuration (%s): %s" % (item.upper(), value))
+                logging.info(
+                    "Environment Configuration (%s): %s" % (item.upper(), value)
+                )
                 options[item] = value
             else:
                 logging.error(

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -11,6 +11,9 @@ footer {
 .footernav {
     padding: 5px 20px;
 }
+.img-polaroid {
+    width: 500px;
+}
 .shortcolumn {
     width: 1px;
     white-space: nowrap;

--- a/templates/public/registration.html
+++ b/templates/public/registration.html
@@ -8,11 +8,11 @@
 {% end %}
 
 {% block modals %}
-{% from libs.XSSImageCheck import get_new_avatar %}
-{% from tornado.options import options %}
-{% from libs.XSSImageCheck import filter_avatars %}
-{% from libs.XSSImageCheck import existing_avatars %}
-{% from models.Team import Team %}
+    {% from libs.XSSImageCheck import get_new_avatar %}
+    {% from tornado.options import options %}
+    {% from libs.XSSImageCheck import filter_avatars %}
+    {% from libs.XSSImageCheck import existing_avatars %}
+    {% from models.Team import Team %}
     <!-- Select Avatar -->
     {% if options.teams %}
         {% set dir = "user" %}
@@ -22,49 +22,48 @@
     {% set avatars = filter_avatars("user") %}
     {% set existing = existing_avatars(dir) %}
     <div id="change-user-avatar-modal" class="modal hide fade" style="display: none; {% if len(avatars) > 0 %}width: 750px; margin-left: -375px;{% end %}">
-    <div class="modal-header">
-        <button id="avatarclose" type="button" class="close" data-dismiss="modal">&times;</button>
-        <h3>{{ _("Select Avatar") }}</h3>
-    </div>
-    <div class="modal-body">
-        {% raw xsrf_form_html() %}
-        {% if len(avatars) > 0 %}
-        <div style="border-top: solid 1px rgb(92, 92, 92); margin-top: -5px; margin-bottom: 20px;"></div>
-        <span style="float: right; padding-right: 10px; margin-top: -15px; font-size: small;"><i class="fa fa-certificate"></i> {{ _("indicates use by another player") }}</span>
-        <br>
-            {% for avatar in avatars[::3] %}
-                <div class="row">
-                    <div class="span3" style="position: relative;">
-                        <center>
-                            {% if avatar in existing %}<i class="fa fa-certificate avatarused"></i><i class="fa fa-certificate avatarused-top"></i>{% end %}
-                            <a href="#" class="useravatarimg" value="{{avatar}}"><img src="/avatars/{{avatar}}"  class="img-polaroid" style="width: 200px;"></a>
-                        </center>
+        <div class="modal-header">
+            <button id="avatarclose" type="button" class="close" data-dismiss="modal">&times;</button>
+            <h3>{{ _("Select Avatar") }}</h3>
+        </div>
+        <div class="modal-body">
+            {% raw xsrf_form_html() %}
+            {% if len(avatars) > 0 %}
+                <div style="border-top: solid 1px rgb(92, 92, 92); margin-top: -5px; margin-bottom: 20px;"></div>
+                <span style="float: right; padding-right: 10px; margin-top: -15px; font-size: small;"><i class="fa fa-certificate"></i> {{ _("indicates use by another player") }}</span>
+                <br>
+                {% for avatar in avatars[::3] %}
+                    <div class="row">
+                        <div class="span3" style="position: relative;">
+                            <center>
+                                {% if avatar in existing %}<i class="fa fa-certificate avatarused"></i><i class="fa fa-certificate avatarused-top"></i>{% end %}
+                                <a href="#" class="useravatarimg" value="{{avatar}}"><img src="/avatars/{{avatar}}"  class="img-polaroid" style="width: 200px;"></a>
+                            </center>
+                        </div>
+                        {% if avatars.index(avatar) + 1 < len(avatars) %}
+                            {% set avatar1 = avatars[avatars.index(avatar) + 1] %}
+                            <div class="span3" style="position: relative;">
+                                <center>
+                                    {% if avatar1 in existing %}<i class="fa fa-certificate avatarused"></i><i class="fa fa-certificate avatarused-top"></i>{% end %}
+                                    <a href="#" class="useravatarimg" value="{{avatar1}}"><img src="/avatars/{{avatar1}}"  class="img-polaroid" style="width: 200px;"></a>
+                                </center>
+                            </div>
+                        {% end %}
+                        {% if avatars.index(avatar) + 2 < len(avatars) %}
+                            {% set avatar2 = avatars[avatars.index(avatar) + 2] %}
+                            <div class="span3" style="position: relative;">
+                                <center>
+                                    {% if avatar2 in existing %}<i class="fa fa-certificate avatarused"></i><i class="fa fa-certificate avatarused-top"></i>{% end %}
+                                    <a href="#" class="useravatarimg" value="{{avatar2}}"><img src="/avatars/{{avatar2}}"  class="img-polaroid" style="width: 200px;"></a>
+                                </center>
+                            </div>
+                        {% end %}
                     </div>
-                    {% if avatars.index(avatar) + 1 < len(avatars) %}
-                        {% set avatar1 = avatars[avatars.index(avatar) + 1] %}
-                        <div class="span3" style="position: relative;">
-                            <center>
-                                {% if avatar1 in existing %}<i class="fa fa-certificate avatarused"></i><i class="fa fa-certificate avatarused-top"></i>{% end %}
-                                <a href="#" class="useravatarimg" value="{{avatar1}}"><img src="/avatars/{{avatar1}}"  class="img-polaroid" style="width: 200px;"></a>
-                            </center>
-                        </div>
-                    {% end %}
-                    {% if avatars.index(avatar) + 2 < len(avatars) %}
-                        {% set avatar2 = avatars[avatars.index(avatar) + 2] %}
-                        <div class="span3" style="position: relative;">
-                            <center>
-                                {% if avatar2 in existing %}<i class="fa fa-certificate avatarused"></i><i class="fa fa-certificate avatarused-top"></i>{% end %}
-                                <a href="#" class="useravatarimg" value="{{avatar2}}"><img src="/avatars/{{avatar2}}"  class="img-polaroid" style="width: 200px;"></a>
-                            </center>
-                        </div>
-                    {% end %}
-                </div>
-                <br/>
+                    <br/>
+                {% end %}
             {% end %}
-        {% end %}
-    
+        </div>
     </div>
-</div>
 {% end %}
 
 {% block content %}
@@ -83,23 +82,25 @@
                 </div>
             {% end %}
         {% end %}
-        <div class="well" style="position: relative;">
+        <div class="{% if len(avatars) == 0 %}span8 offset1 {% end %}well" style="position: relative;">
         {% if not suspend %}
             <legend>
                 {{ _("Welcome to the Scene") }}
             </legend><!-- http://www.youtube.com/watch?v=xIs_5nfJKu4&list=PLC2FCB2871C396459 -->
             <form class="form-horizontal" action="/registration" method="post" enctype="multipart/form-data">
                 {% raw xsrf_form_html() %}
-                {% set avatarimg = get_new_avatar("user", not options.teams) %}
-                <div class="control-group" style="float: right; position: absolute; right: 30px; top: 40px;">
-                    <img id="avatarimage" src="/avatars/{{avatarimg}}" class="img-polaroid" style="width: 350px; height: 175px; object-fit: cover"/>
-                    <div class="controls" style="margin-top: 15px; margin-left: 0px;">
-                        <input id="user_avatar_select" name="user_avatar_select" type="hidden" value="{{avatarimg}}" />
-                        {% if len(avatars) > 0 %}<a data-toggle="modal" class="btn btn-primary" href="#change-user-avatar-modal"> {{ _("Select New Avatar") }} </a>&nbsp;&nbsp;{% end %}
-                        <a id="uploadbutton" class="btn btn-primary" href="#">{{ _("Upload Avatar") }}</a>&nbsp;&nbsp;(w500 x h250)
-                        <input id="user-avatar" name="avatar" type="file" style="display: none;"/>
-                     </div>
-                </div>
+                {% if len(avatars) > 0 %}
+                    {% set avatarimg = get_new_avatar("user", not options.teams) %}
+                    <div class="control-group" style="float: right; position: absolute; right: 30px; top: 40px;">
+                        <img id="avatarimage" src="/avatars/{{avatarimg}}" class="img-polaroid" style="width: 350px; height: 175px; object-fit: cover"/>
+                        <div class="controls" style="margin-top: 15px; margin-left: 0px;">
+                            <input id="user_avatar_select" name="user_avatar_select" type="hidden" value="{{avatarimg}}" />
+                            {% if len(avatars) > 0 %}<a data-toggle="modal" class="btn btn-primary" href="#change-user-avatar-modal"> {{ _("Select New Avatar") }} </a>&nbsp;&nbsp;{% end %}
+                            <a id="uploadbutton" class="btn btn-primary" href="#">{{ _("Upload Avatar") }}</a>&nbsp;&nbsp;(w500 x h250)
+                            <input id="user-avatar" name="avatar" type="file" style="display: none;"/>
+                        </div>
+                    </div>
+                {% end %}
                 <div class="control-group">
                     <label class="control-label" for="handle">
                         <i class="fa fa-user"></i>


### PR DESCRIPTION
Identicon avatars if no user or team avatars are supplied in the avatar directory by the admin.  This just replaces the default avatar image, which was the same for every user.  Based on player handle or team name.  The admin can use the old default image by just dragging it into the user or team directory.  The identicon is only used when no other avatar images are supplied.