### PR TITLE
Add option to use SSL on MySQL connection.

### DIFF
--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -262,6 +262,7 @@ def update_db(update=True):
         username=options.sql_user,
         password=options.sql_password,
         dialect=options.sql_dialect,
+        ssl_ca=options.sql_sslca,
     )
     alembic_cfg = Config("alembic/alembic.ini")
     alembic_cfg.attributes["configure_logger"] = False

--- a/libs/DatabaseConnection.py
+++ b/libs/DatabaseConnection.py
@@ -40,7 +40,7 @@ from tornado.options import options
 
 class DatabaseConnection(object):
     def __init__(
-        self, database, hostname="", port="", username="", password="", dialect=""
+        self, database, hostname="", port="", username="", password="", dialect="", ssl_ca=""
     ):
         self.database = database
         self.hostname = hostname
@@ -48,6 +48,7 @@ class DatabaseConnection(object):
         self.username = username
         self.password = password
         self.dialect = dialect
+        self.ssl_ca = ssl_ca
 
     def __str__(self):
         """ Construct the database connection string """
@@ -109,6 +110,10 @@ class DatabaseConnection(object):
             db_name,
             db_charset,
         )
+
+        if self.ssl_ca != "":
+            db_connection = db_connection + "&ssl_ca=" + self.ssl_ca
+
         codecs.register(
             lambda name: codecs.lookup("utf8") if name == "utf8mb4" else None
         )

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -58,6 +58,7 @@ db_connection = DatabaseConnection(
     username=options.sql_user,
     password=options.sql_password,
     dialect=options.sql_dialect,
+    ssl_ca=options.sql_sslca,
 )
 
 

--- a/rootthebox.py
+++ b/rootthebox.py
@@ -459,6 +459,8 @@ define("sql_port", default=3306, group="database", help="database tcp port", typ
 
 define("sql_user", default="rtb", group="database", help="database username")
 
+define("sql_sslca", default="", group="database", help="SSL CA Cert for database server.")
+
 define(
     "sql_password",
     default="rtb",


### PR DESCRIPTION
Some MySQL databases particularly cloud hosted ones such as [Azure Database for MySQL][azdb4mysql] require the use of SSL connections. Currently the database connection configuration does not support this.

This PR adds the option `sql_sslca` which should be set to the path of a public certificate file that can be used to validate the server certificate of the database. For [Azure Database for MySQL][azdb4mysql] details of how to obtain this certificate can be found at [Obtain SSL certificate][azdbgetcert]. The certificate file would likely be put in the `files/` directory.

[azdb4mysql]: https://azure.microsoft.com/services/mysql/ "Azure Database for MySQL"
[azdbgetcert]: https://docs.microsoft.com/azure/mysql/howto-configure-ssl#step-1-obtain-ssl-certificate "Configure SSL connectivity in your application to securely connect to Azure Database for MySQL"