### PR TITLE
Process environment variables before database setup in docker configuration.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,7 @@ RUN apt-get install python3-pycurl sqlite3 libsqlite3-dev -y
 ADD ./setup/requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt --upgrade
 
+ENV SQL_DIALECT=sqlite
+
 VOLUME ["/opt/rtb/files"]
-ENTRYPOINT ["python3", "/opt/rtb/rootthebox.py", "--setup=docker", "--sql_dialect=sqlite"]
+ENTRYPOINT ["python3", "/opt/rtb/rootthebox.py", "--setup=docker"]

--- a/rootthebox.py
+++ b/rootthebox.py
@@ -960,6 +960,7 @@ if __name__ == "__main__":
             options.admin_ips = []  # Remove admin ips due to docker 127.0.0.1 mapping
             options.memcached = "memcached"
             options.x_headers = True
+            options_parse_environment()  # Pick up env vars before saving config file.
             save_config()
             setup()
         else:


### PR DESCRIPTION
When running in a docker container, some settings such as those needed for database connection, might be defined in environment variables.

This PR ensures that the environment variables are processed before running the database setup. This also enables the database type to be overridden in the [Dockerfile](https://github.com/moloch--/RootTheBox/blob/master/Dockerfile). It will still default to `sqlite`.