### PR TITLE
Add auto generation features

### DIFF
--- a/rootthebox.py
+++ b/rootthebox.py
@@ -1053,6 +1053,9 @@ if __name__ == "__main__":
     if options.add_admin:
         generate_admins(options.add_admin)
 
+    if options.admin_ips == ['[]']:
+        options.admin_ips = [] # Tornado issue?
+
     if options.setup.lower()[:3] in ["pro", "dev"]:
         setup()
     elif options.start:

--- a/rootthebox.py
+++ b/rootthebox.py
@@ -144,6 +144,44 @@ def setup_xml(xml_params):
         import_xml(xml_param)
     print(INFO + "%s : Completed processing of all .xml file(s)" % (current_time()))
 
+def generate_teams(num_teams):
+    """ Generates teams by number """
+    from models import Team, dbsession
+    for i in range(0, num_teams):
+        team = Team()
+        team.name = 'Team ' + str(i+1)
+        dbsession.add(team)
+        dbsession.flush()
+    dbsession.commit()
+
+def generate_teams_by_name(team_names):
+    """ Generates teams by their names """
+    from models import Team, dbsession
+    for i in range(0, len(team_names)):
+        team = Team()
+        team.name = team_names[i]
+        dbsession.add(team)
+        dbsession.flush()
+    dbsession.commit()
+
+def generate_admins(admin_names):
+    """ Creates admin users with the syntax '<handle> <email> <password>' """
+    from models import User, Permission, dbsession
+    from models.User import ADMIN_PERMISSION
+    for i in range(0, len(admin_names)):
+        admin_detail = admin_names[i].split()
+        user = User(
+            handle=admin_detail[0],
+            name=admin_detail[0],
+            email=admin_detail[1],
+            password=admin_detail[2])
+        dbsession.add(user)
+        dbsession.flush()
+
+        admin_permission = Permission(name=ADMIN_PERMISSION, user_id=user.id)
+        dbsession.add(admin_permission)
+        dbsession.flush()
+    dbsession.commit()
 
 def tests():
     """ Creates a temporary sqlite database and runs the unit tests """
@@ -920,6 +958,31 @@ define(
     type=game_type,
 )
 
+# Auto-setup modes
+define(
+    "generate_teams",
+    default=0,
+    group="autosetup",
+    help="number of teams to generate (team 1, team 2, etc)",
+    type=int
+)
+
+define(
+    "generate_team",
+    default=[],
+    group="autosetup",
+    help="generate teams by name ('My team','Another team')",
+    multiple=True
+)
+
+define(
+    "add_admin",
+    default=[],
+    group="autosetup",
+    help="add administrator users, multiples supported ('<handle> <email> <password>')",
+    multiple=True
+)
+
 # Process modes/flags
 define("setup", default="", help="setup a database (prod|devel|docker)")
 
@@ -982,6 +1045,13 @@ if __name__ == "__main__":
 
     # Make sure that cli args always have president over the file and env
     options.parse_command_line()
+
+    if options.generate_teams:
+        generate_teams(options.generate_teams)
+    if options.generate_team:
+        generate_teams_by_name(options.generate_team)
+    if options.add_admin:
+        generate_admins(options.add_admin)
 
     if options.setup.lower()[:3] in ["pro", "dev"]:
         setup()


### PR DESCRIPTION
Adds CLI args:
* --generate_teams=N ... Generates N numbered teams. e.g. "Team 1", "Team 2" ...
* --generate_team="My Team", "Their Team", "Another Team" ... Generates teams from a comma-delimited list of names
* --add_admin="handle handle@contoso.com passwordpassword123" ... Generates admins from a comma-delimited list of strings, formatted as seen in the example here.

This also fixes an issue where [] in the configuration would be parsed as (literally) ['[]'] -- this is reverted to proper format before continuing the load process