### PR TITLE
Add option to authenticate with Azure AD.

### DIFF
--- a/handlers/PublicHandlers.py
+++ b/handlers/PublicHandlers.py
@@ -28,7 +28,7 @@ any authentication) with the exception of error handlers and the scoreboard
 import logging
 import re
 import smtplib
-import random
+import secrets
 import string
 
 from os import urandom
@@ -163,7 +163,7 @@ class CodeFlowHandler(BaseHandler):
         user.uuid = claims["oid"]
         user.handle = claims["preferred_username"].split("@")[0]
         # Generate a long random password that the user will never know or use.
-        user.password = ''.join(random.choices(string.ascii_letters + string.digits + string.punctuation, k=30))
+        user.password = ''.join(secrets.choice(string.ascii_letters + string.digits + string.punctuation) for i in range(30))
         user.bank_password = False
         user.name = claims["name"]
         user.email = claims["email"]

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -86,10 +86,7 @@ def get_cookie_secret():
 urls = [
     # Public handlers - PublicHandlers.py
     (r"/login", LoginHandler),
-    (r"/registration", RegistrationHandler),
-    (r"/registration/token", ValidEmailHandler),
-    (r"/reset", ForgotPasswordHandler),
-    (r"/reset/token", ResetPasswordHandler),
+    (r"/oidc", CodeFlowHandler),
     (r"/about", AboutHandler),
     (r"/", HomePageHandler),
     (r"/robots(|\.txt)", FakeRobotsHandler),
@@ -203,6 +200,17 @@ urls = [
     (r"/(.*)phpmyadmin(.*)", NoobHandler),
     (r"/administrator(.*)", NoobHandler),
 ]
+
+# These routes should be disabled if we're not using the database for authentication.
+# If database auth is used add them in.
+if options.auth == "db":
+    urls.insert(2, (r"/reset/token", ResetPasswordHandler))
+    urls.insert(2, (r"/reset", ForgotPasswordHandler))
+    urls.insert(2, (r"/registration/token", ValidEmailHandler))
+    urls.insert(2, (r"/registration", RegistrationHandler))
+# For Azure AD authentication we have a simplified Join Team instead of registration.
+elif options.auth == "azuread":
+    urls.insert(2, (r"/jointeam", JoinTeamHandler))
 
 # This one has to be last
 urls.append((r"/(.*)", NotFoundHandler))

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -30,6 +30,7 @@ from contextlib import contextmanager
 from libs.DatabaseConnection import DatabaseConnection
 from libs.ConsoleColors import *
 from builtins import str
+from msal import ConfidentialClientApplication
 
 
 if options.log_sql:
@@ -60,6 +61,14 @@ db_connection = DatabaseConnection(
     dialect=options.sql_dialect,
 )
 
+if options.auth == "azuread":
+    azuread_app = ConfidentialClientApplication (
+        options.client_id,
+        authority = "https://login.microsoftonline.com/" + options.tenant_id,
+        client_credential = options.client_secret
+    )
+else:
+    azuread_app = None
 
 ### Setup the database session
 engine = create_engine(str(db_connection), pool_pre_ping=True)

--- a/modules/Menu.py
+++ b/modules/Menu.py
@@ -37,6 +37,7 @@ class Menu(UIModule):
         else:
             user = None
         scoreboard_visible = self.scoreboard_visible(user)
+        registration_allowed = self.registration_allowed()
         if self.handler.session is not None:
             if self.handler.session["menu"] == "user":
                 return self.render_string(
@@ -47,7 +48,7 @@ class Menu(UIModule):
                     "menu/admin.html", user=user, scoreboard_visible=scoreboard_visible
                 )
         return self.render_string(
-            "menu/public.html", scoreboard_visible=scoreboard_visible
+            "menu/public.html", scoreboard_visible=scoreboard_visible, registration_visible=registration_allowed
         )
 
     def scoreboard_visible(self, user):
@@ -56,3 +57,8 @@ class Menu(UIModule):
         if user:
             return options.scoreboard_visibility == "players" or user.is_admin()
         return False
+
+    def registration_allowed(self):
+        if options.auth == "azuread":
+            return False
+        return True

--- a/rootthebox.py
+++ b/rootthebox.py
@@ -342,6 +342,13 @@ define(
 )
 
 define(
+    "auth",
+    default="db",
+    group="application",
+    help="The authentication mechanism, db (default) or Azure AD",
+)
+
+define(
     "avatar_dir",
     default="./files/avatars",
     group="application",
@@ -415,6 +422,12 @@ define(
     group="application",
     help="links to add to the tool menu",
 )
+
+# Azure AD
+define("client_id", default="", group="azuread" )
+define("tenant_id", default="common", group="azuread" )
+define("client_secret", default="", group="azuread" )
+define("redirect_url", default="http://localhost:8888/oidc", group="azuread" )
 
 # ReCAPTCHA
 define(
@@ -982,6 +995,13 @@ if __name__ == "__main__":
 
     # Make sure that cli args always have president over the file and env
     options.parse_command_line()
+
+    # If authenticating with Azure AD (i.e. enterprise scenario) There's a few settings which 
+    # don't make sense, so force them to disabled.
+    if options.auth.lower() == 'azuread':
+        options.auth = 'azuread' # in-case it wasn't lower-case.
+        options.require_email = False
+        options.public_teams = False
 
     if options.setup.lower()[:3] in ["pro", "dev"]:
         setup()

--- a/setup/bootstrap.py
+++ b/setup/bootstrap.py
@@ -44,6 +44,7 @@ if (
     options.setup.lower().startswith("dev")
     or options.setup.lower().startswith("docker")
     or options.tests
+    or options.auth.lower() == "azuread"
 ):
     admin_handle = "admin"
     password = "rootthebox"
@@ -133,12 +134,14 @@ game_level = GameLevel(number=0, buyout=0)
 dbsession.add(game_level)
 dbsession.flush()
 
-# Admin User Account
-admin_user = User(handle=admin_handle)
-admin_user.password = password
-dbsession.add(admin_user)
-dbsession.flush()
+if options.auth.lower() == "db":
+    # Admin User Account
+    admin_user = User(handle=admin_handle)
+    admin_user.password = password
+    dbsession.add(admin_user)
+    dbsession.flush()
 
-admin_permission = Permission(name=ADMIN_PERMISSION, user_id=admin_user.id)
-dbsession.add(admin_permission)
+    admin_permission = Permission(name=ADMIN_PERMISSION, user_id=admin_user.id)
+    dbsession.add(admin_permission)
+
 dbsession.commit()

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -14,3 +14,4 @@ alembic
 enum34
 mysqlclient
 rocketchat_API
+msal

--- a/templates/menu/public.html
+++ b/templates/menu/public.html
@@ -24,12 +24,14 @@
                             {{ _("Login") }}
                         </a>
                     </li>
+                    {% if registration_visible %}
                     <li>
                         <a href="/registration">
                             <i class="fa fa-fw fa-pencil"></i>
                             {{ _("Registration") }}
                         </a>
                     </li>
+                    {% end %}
                     {% if scoreboard_visible %}
                     <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">

--- a/templates/public/jointeam.html
+++ b/templates/public/jointeam.html
@@ -1,0 +1,83 @@
+{% extends "../main.html" %}
+
+{% block title %}{{ _("Join a Team") }}{% end %}
+
+{% block header %}
+    <link rel="stylesheet" href="/static/css/pages/public/registration.css" type="text/css" />
+    <script src="/static/js/pages/public/registration.js"></script>
+{% end %}
+
+{% block content %}
+    {% from tornado.options import options %}
+    <div class="container">
+        <h1>
+            <i class="fa fa-users"></i>
+            {{ _("Join a Team") }}
+        </h1>
+        <br />
+        {% if errors is not None and len(errors) != 0 %}
+            {% for error in errors %}
+                <div class="alert alert-error">
+                    <a class="close" data-dismiss="alert" href="#">&times;</a>
+                    <h4 class="alert-heading">{{ _("ERROR") }}</h4>
+                    {{ error }}
+                </div>
+            {% end %}
+        {% end %}
+        <div class="span8 offset1 well" style="position: relative;">
+        {% if not suspend %}
+            <legend>
+                {{ _("Welcome to the Scene") }}
+            </legend>
+            <form class="form-horizontal" action="/jointeam" method="post" enctype="multipart/form-data">
+                {% raw xsrf_form_html() %}
+                <hr style="margin-right: 400px;">
+                <h5 style="margin-left: 20px; margin-bottom: 15px;">{{ _("Join Existing Team") }}</h5>
+                <div id="teammode-join" class="control-group">
+                    <label class="control-label" for="team-code">{{ _("Team Code") }}</label>
+                    <div class="controls">
+                        <input id="team-code" name="team-code" type="text" placeholder="{{ _('Team Code') }}"
+                            rel="popover"
+                            data-original-title="{{_('Team Code')}}"
+                            data-content="{{_('Provide the code used to join an existing team.  Visible to other team members on their home page.')}}" >
+                    </div>
+                </div>
+
+                <hr style="margin-right: 400px;">
+
+                {% if options.banking %}
+                <div class="control-group">
+                    <label class="control-label" for="bpass1">{{ _("Bank Account Password") }}</label>
+                    <div class="controls">
+                        <input required id="bpass" name="bpass" maxlength="{{ options.max_password_length }}" placeholder="{{ _('Bank Account Password') }}" type="password"
+                            autocomplete="off"
+                            rel="popover"
+                            data-original-title="{{_('Password')}}"
+                            data-content="{{_('Used to secure your (in-game) bank account.')}} [{{ _('Max') }}: {{ options.max_password_length }} {{_('Characters')}}].  {{_('Please do NOT enter your real bank account password.')}}" />
+                    </div>
+                </div>
+                {% end %}
+                {% if options.privacy_policy_link %}
+                    <div class="control-group">
+                        <label class="control-label" for="privacy_policy_accept">{{ _("I accept the") }} <a href="{{ options.privacy_policy_link }}">{{ _("Privacy Policy") }}</a></label>
+                        <div class="controls">
+                            <input required id="privacy_policy_accept" name="privacy_policy_accept" type="checkbox" />
+                        </div>
+                    </div>
+                {% end %}
+                <br />
+                <input id="login-hint" name="login-hint" type="hidden" value="{{ login_hint }}" />
+                <div class="control-group">
+                    <div class="controls">
+                        <button class="btn btn-primary" type="submit">
+                            {{ _("Join") }}
+                        </button>
+                    </div>
+                </div>
+            </form>
+        {% else %}
+            <h4 style="text-align: center;"><i class="fa fa-group"></i>&nbsp;&nbsp;{{ _("The game is not accepting new players at this time.") }}</h4>
+        {% end %}
+        </div>
+    </div>
+{% end %}

--- a/templates/user/settings.html
+++ b/templates/user/settings.html
@@ -268,6 +268,7 @@
                 </form>
             </div>
         </div>
+        {% if options.auth == "db" %}
         <div class="row" style="margin-left: 0px; margin-right: 20px;">
             <div class="well">
                 <form class="form-horizontal" action="/user/settings/password" method="post" autocomplete="off">
@@ -302,6 +303,7 @@
                 </form>
             </div>
         </div>
+        {% end %}
         {% if options.banking %}
         <div class="row-fluid" style="margin-left: 0px;">
             <div class="well" style="margin-right: 20px;">


### PR DESCRIPTION
This is quite a big change.

It adds the option to use [Azure Active Directory (Azure AD)][aad] instead of the username/password stored in the database.

There is a new option `auth` that can be set to `db` (the default) or `azuread`.

It uses the [Microsoft Authentication Library (MSAL)][msal] to handle the redirect using the [OpenID Connect (OIDC) authorisation code flow][codeflow].

Entries are still added to the user table using object identifier from Azure AD to match to the `uuid` field in the database.

Admin permission is now governed by an [AppRole][approle] in Azure AD. Admins can then be managed centrally. The admin permission is updated in the database on log in to ensure consistency with rest of the application.

To configure the application for Azure AD authentication the following options need to be set:
  * `auth` = `azuread`
  * `client_id` = the client id/app id of the application registration in Azure AD
  * `tenant_id` = the identifier for the Azure AD tenant (a GUID)
  * `client_secret` = the secret key in Azure AD used to authenticate the application with Azure AD.
  * `redirect_url` = the fully qualified URL that Azure AD will redirect to after the user signs in.

Note, the `redirect_url` default to http://localhost:8888/oidc. The /oidc path is handled by the new `CodeFlowHandler` in `PublicHandlers.py`.

Registration is disables in `azuread` mode, and a new 'Join Team' page allows a new user to join an existing team.

[aad]: https://azure.microsoft.com/services/active-directory/ "Azure Active Directory"
[msal]: https://github.com/AzureAD/microsoft-authentication-library-for-python "Microsoft Authentication Library (MSAL) for Python"
[approle]: https://go.microsoft.com/fwlink/?linkid=2138582 "Assign users and groups to roles"
[codeflow]: https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code "Microsoft identity platform and OAuth 2.0 authorization code flow"