### PR TITLE
Make setup idempotent.

### DIFF
--- a/rootthebox.py
+++ b/rootthebox.py
@@ -101,6 +101,14 @@ def setup():
 
     create_tables(engine, metadata, options.log_sql)
     sys.stdout.flush()
+
+    from models.Theme import Theme
+
+    themes = Theme.all()
+    if len(themes) > 0:
+        print(INFO + "It looks like database has already been set up.")
+        return
+
     print(INFO + "%s : Bootstrapping the database ..." % current_time())
     import setup.bootstrap
 


### PR DESCRIPTION
If you run `--setup` more than once it will fail because the [`bootstrap`](https://github.com/moloch--/RootTheBox/blob/master/setup/bootstrap.py) tries to write database rows that already exist.

This is really a problem following #431 which allows a container deployment to use an external database. A container restart causes the application to fail because `--setup=docker` tries to bootstrap the database again.

This change checks whether any rows exist in the `theme` table (the first one populated by the bootstrap). If there are, it quits the setup.

This could be made far more thorough, checking each row populated by the bootstrap, however this quick hack does allow  a container to restart successfully.