### PR TITLE
VS Code Dev Container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,40 @@
+FROM python:3.8
+
+ADD [ "https://dev.mysql.com/get/mysql-apt-config_0.8.16-1_all.deb", "/" ]
+
+RUN apt-get -qq update \
+	&& export DEBIAN_FRONTEND=noninteractive \
+	&& apt-get -qq upgrade -y \
+	&& apt-get -qq install -y --no-install-recommends \
+		lsb-release \
+		locales \
+		build-essential \
+		zlib1g-dev \
+		python3-pycurl \
+	# MySQL Tools
+	&& dpkg -i /mysql-apt-config_0.8.16-1_all.deb \
+	&& apt-get -qq update \
+	&& apt-get -qq install -y --no-install-recommends \
+		mysql-shell \
+		mysql-client \
+	# Clean up
+	&& apt-get autoremove -y \
+	&& apt-get clean -y \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm mysql-apt-config*.deb
+
+# Generate the en_US.UTF-8 locale used by mysqlsh
+RUN sed -Ei 's/^# en_US\.UTF-8 UTF-8$/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
+
+COPY ./setup/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt --upgrade && pip install --upgrade pylint
+
+# Create a new user dev (1000 matches the default user in WSL)
+ARG USERNAME=rtbdev
+ARG UID=1000
+ARG GID=1000
+RUN groupadd --gid $GID $USERNAME
+RUN useradd --create-home --shell /bin/bash --uid $UID --gid $GID $USERNAME
+
+# Run with dev user
+USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,12 @@
 					"type": "python",
 					"request": "launch",
 					"program": "rootthebox.py",
-					"args": [ "--start", "--debug" ],
+					"args": [ 
+						"--start", 
+						"--debug",
+						"--autostart_game=True",
+						"--autoreload_source=False" 
+					],
 					"console": "integratedTerminal",
 					"serverReadyAction": {
 						"action": "openExternally",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,48 @@
+{
+	"name": "rootthebox",
+	"dockerComposeFile": ["../docker-compose.yml", "docker-compose.dev.yml"],
+	"service": "webapp",
+	"workspaceFolder": "/home/rtbdev/code/",
+	"extensions": [
+		"ms-python.python",
+		"redhat.vscode-xml"
+	],
+	"forwardPorts": [ 8888 ],
+	"settings": {
+		"terminal.integrated.cwd": "/home/rtbdev/code/",
+		"files.exclude": {
+			"**/.devcontainer": true,
+			"**/.vscode": true
+		},
+		"launch": {
+			"configurations": [
+				{
+					"name": "RootTheBox",
+					"type": "python",
+					"request": "launch",
+					"program": "rootthebox.py",
+					"args": [ "--start", "--debug" ],
+					"console": "integratedTerminal",
+					"serverReadyAction": {
+						"action": "openExternally",
+						"pattern": "Starting RTB on http://localhost:([0-9]+)",
+						"uriFormat": "http://localhost:%s"
+					}
+				}
+			]
+		}
+	},
+	"postCreateCommand": [
+		"/usr/local/bin/python3",
+		"/home/rtbdev/code/rootthebox.py",
+		"--setup=prod",
+		"--tests",
+		"--sql_dialect=mysql",
+		"--sql_host=mysql",
+		"--sql_user=rtb",
+		"--sql_password=rootthebox",
+		"--memcached=memcached",
+		"--admin_ips=[]",
+		"--debug"
+	]
+}

--- a/.devcontainer/docker-compose.dev.yml
+++ b/.devcontainer/docker-compose.dev.yml
@@ -1,0 +1,35 @@
+services:
+  webapp:
+    hostname: 'rtbdev'
+    build:
+      context: .
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - .:/home/rtbdev/code/:cached
+    command: /bin/sh -c "while sleep 1000; do :; done"
+    depends_on:
+      mysql:
+        condition: service_healthy
+      memcached:
+        condition: service_started
+
+  mysql:
+    image: mysql:8.0
+    hostname: 'mysql'
+    command: >-
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_general_ci
+      --skip-name-resolve=OFF
+      --default-authentication-plugin=mysql_native_password
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -P 3306 | grep 'mysqld is alive' || exit 1"]
+      interval: 5s
+      timeout: 30s
+      retries: 12
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=True
+      - MYSQL_DATABASE=rootthebox
+      - MYSQL_USER=rtb
+      - MYSQL_PASSWORD=rootthebox

--- a/RootTheBox.code-workspace
+++ b/RootTheBox.code-workspace
@@ -1,0 +1,9 @@
+{
+	"folders": [
+		{
+			"name": "RootTheBox",
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.0"
 services:
   memcached:
     image: memcached:latest

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -249,6 +249,7 @@ app = Application(
     scoreboard_state={},
     # Application version
     version=__version__,
+    autoreload=options.autoreload_source
 )
 
 

--- a/rootthebox.py
+++ b/rootthebox.py
@@ -306,6 +306,13 @@ define(
     help="whitelist of ip addresses that can access the admin ui (use empty list to allow all ip addresses)",
 )
 
+define(
+    "autoreload_source",
+    default=True,
+    group="server",
+    help="automatically restart the server if a change is detected in source (debuggers will not follow)"
+)
+
 # Mail Server
 define("mail_host", default="", group="mail", help="SMTP server")
 
@@ -975,7 +982,8 @@ if __name__ == "__main__":
             + bold
             + "If necessary, update the db username and password in the cfg and set any advanced configuration options."
         )
-        os._exit(1)
+        if not options.setup:
+            os._exit(1)
     else:
         logging.debug("Parsing config file `%s`" % (os.path.abspath(options.config),))
         options.parse_config_file(options.config)


### PR DESCRIPTION
To make development easier by having a ready to go development environment.

This PR adds the files needed to set up a [Dev Container][devcontainers] in [Visual Stidio Code][vscode].

It uses the [docker-compose][compose] configuration to set up three containers, one for the __RootTheBox__ app, one for __memcached__, and one for __MySQL__. A custom Dockerfile is used for the development environment that has the MySQL tools installed on it.

Once the containers have started, the `postCreateCommand` runs the RootTheBox setup to create the database.

Once hit [Run to start debugging][debug]. 

~~___NOTE:__ There is one issue that I've not managed to figure out yet. The very first time you set up the containers with a completely clean repo the database setup fails (it can't connect to the database). However once you have a `./files/rootthebox.cfg` it seems to work fine, even if you removed all the containers._~~ Kudos to @anthturner for fixing this.

[vscode]: https://code.visualstudio.com/ "Visual Studio Code - Code editing. Redefined."
[devcontainers]: https://code.visualstudio.com/docs/remote/create-dev-container "Create a development container"
[compose]: https://code.visualstudio.com/docs/remote/create-dev-container#_use-docker-compose "Use Docker Compose"
[debug]: https://code.visualstudio.com/docs/python/debugging "Python debug configurations in Visual Studio Code"