### PR TITLE
Add Support for Webhooks

### DIFF
--- a/handlers/BaseHandlers.py
+++ b/handlers/BaseHandlers.py
@@ -36,6 +36,7 @@ from models.User import User
 from libs.SecurityDecorators import *
 from libs.Sessions import MemcachedSession, MemcachedConnect
 from libs.EventManager import EventManager
+from libs.WebhookHelpers import *
 from builtins import str
 
 try:
@@ -256,6 +257,8 @@ class BaseHandler(RequestHandler):
             self.application.settings["history_callback"].start()
             if self.config.use_bots:
                 self.application.settings["score_bots_callback"].start()
+            # Fire game start webhook
+            send_game_start_webhook()
 
     def stop_game(self):
         """ Stop the game and all callbacks """
@@ -266,6 +269,8 @@ class BaseHandler(RequestHandler):
                 self.application.settings["history_callback"].stop()
             if self.application.settings["score_bots_callback"]._running:
                 self.application.settings["score_bots_callback"].stop()
+            # Fire game stop webhook
+            send_game_stop_webhook()
 
     def get_user_locale(self):
         """

--- a/handlers/MissionsHandler.py
+++ b/handlers/MissionsHandler.py
@@ -33,6 +33,7 @@ from builtins import str
 from past.utils import old_div
 from libs.SecurityDecorators import authenticated, game_started
 from libs.StringCoding import decode, encode
+from libs.WebhookHelpers import *
 from handlers.BaseHandlers import BaseHandler
 from models.GameLevel import GameLevel
 from models.Flag import Flag
@@ -279,6 +280,9 @@ class BoxHandler(BaseHandler):
             )
         success = [reward_dialog]
 
+        # Fire capture webhook
+        send_capture_webhook(user, flag, old_reward)
+
         # Check for Box Completion
         box = flag.box
         if box.is_complete(user):
@@ -292,6 +296,9 @@ class BoxHandler(BaseHandler):
                 success.append(
                     "Congratulations! You have completed " + box.name + ". " + dialog
                 )
+
+                # Fire box complete webhook
+                send_box_complete_webhook(user, box)
             else:
                 success.append("Congratulations! You have completed " + box.name + ".")
 
@@ -328,6 +335,9 @@ class BoxHandler(BaseHandler):
                 + ". "
                 + reward_dialog
             )
+
+            # Fire level complete webhook
+            send_level_complete_webhook(user, box)
 
         # Unlock next level if based on Game Progress
         next_level = GameLevel.by_id(level.next_level_id)
@@ -374,6 +384,10 @@ class BoxHandler(BaseHandler):
             self.dbsession.flush()
             self.event_manager.flag_penalty(user, flag)
             self.dbsession.commit()
+
+            # Fire capture failed webhook
+            send_capture_failed_webhook(user, flag)
+
             return penalty
         return False
 

--- a/libs/WebhookHelpers.py
+++ b/libs/WebhookHelpers.py
@@ -21,6 +21,7 @@ Created on Apr 2, 2021
 # pylint: disable=unused-variable
 
 import logging
+import requests
 from tornado.options import options
 
 def send_game_start_webhook():
@@ -81,7 +82,10 @@ def get_user_info(user):
 def get_team_info(team):
     return {
         'name': team.name,
-        'score': team.get_score(),
+        'money': team.get_score("money"),
+        'flags': team.get_score("flag"),
+        'hints': team.get_score("hint"),
+        'bots': team.get_score("bot"),
         'members': get_team_members(team)
     }
 
@@ -93,8 +97,8 @@ def get_team_members(team):
 
 def send_webhook(data):
     if options.webhook_url:
-        logging.info("Sending webhook for '" + data.action + "' to " + options.webhook_url)
+        logging.info("Sending webhook for '" + data['action'] + "' to " + options.webhook_url)
         try:
-            requests.post("url", data)
+            requests.post(options.webhook_url, json=data)
         except requests.exceptions.RequestException:
             logging.exception("error sending webhook")

--- a/libs/WebhookHelpers.py
+++ b/libs/WebhookHelpers.py
@@ -60,7 +60,12 @@ def send_capture_failed_webhook(user, flag):
 def send_level_complete_webhook(user, level):
     send_webhook({
         'action': 'level_complete',
-        'level': {},
+        'level': {
+            'name': level.name,
+            'number': level.number,
+            'type': level.type,
+            'reward': level.reward
+        },
         'user': get_user_info(user),
         'team': get_team_info(user.team)
     })
@@ -68,7 +73,12 @@ def send_level_complete_webhook(user, level):
 def send_box_complete_webhook(user, box):
     send_webhook({
         'action': 'box_complete',
-        'box': {},
+        'box': {
+            'name': box.name,
+            'value': box.value,
+            'operating_system': box.operating_system,
+            'difficulty': box.difficulty
+        },
         'user': get_user_info(user),
         'team': get_team_info(user.team)
     })

--- a/libs/WebhookHelpers.py
+++ b/libs/WebhookHelpers.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Apr 2, 2021
+
+@author: anthturner
+
+    Copyright 2021 Root the Box
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+# pylint: disable=unused-variable
+
+import logging
+from tornado.options import options
+
+def send_game_start_webhook():
+    send_webhook({
+        'action': 'game_start'
+    })
+
+def send_game_stop_webhook():
+    send_webhook({
+        'action': 'game_stop'
+    })
+
+def send_capture_webhook(user, flag, reward):
+    send_webhook({
+        'action': 'capture_flag',
+        'flag': {
+            'name': flag.name,
+            'original_value': flag.value,
+            'value': reward
+        },
+        'user': get_user_info(user),
+        'team': get_team_info(user.team)
+    })
+
+def send_capture_failed_webhook(user, flag):
+    send_webhook({
+        'action': 'capture_failed',
+        'flag': {
+            'name': flag.name,
+            'original_value': flag.value
+        },
+        'user': get_user_info(user),
+        'team': get_team_info(user.team)
+    })
+
+def send_level_complete_webhook(user, level):
+    send_webhook({
+        'action': 'level_complete',
+        'level': {},
+        'user': get_user_info(user),
+        'team': get_team_info(user.team)
+    })
+
+def send_box_complete_webhook(user, box):
+    send_webhook({
+        'action': 'box_complete',
+        'box': {},
+        'user': get_user_info(user),
+        'team': get_team_info(user.team)
+    })
+
+def get_user_info(user):
+    return {
+        'handle': user.handle,
+        'email': user.email
+    }
+
+def get_team_info(team):
+    return {
+        'name': team.name,
+        'score': team.get_score(),
+        'members': get_team_members(team)
+    }
+
+def get_team_members(team):
+    team_members = []
+    for team_member in team.members:
+        team_members.append(get_user_info(team_member))
+    return team_members
+
+def send_webhook(data):
+    if options.webhook_url:
+        logging.info("Sending webhook for '" + data.action + "' to " + options.webhook_url)
+        try:
+            requests.post("url", data)
+        except requests.exceptions.RequestException:
+            logging.exception("error sending webhook")

--- a/rootthebox.py
+++ b/rootthebox.py
@@ -306,6 +306,13 @@ define(
     help="whitelist of ip addresses that can access the admin ui (use empty list to allow all ip addresses)",
 )
 
+define(
+    "webhook_url",
+    default=None,
+    group="server",
+    help="url to receive webhook callbacks when certain game actions occur, such as flag capture"
+)
+
 # Mail Server
 define("mail_host", default="", group="mail", help="SMTP server")
 

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -14,3 +14,4 @@ alembic
 enum34
 mysqlclient
 rocketchat_API
+requests


### PR DESCRIPTION
When certain game actions occur, a JSON document is POSTed to a given URL. The expectation is that something is listening on the other end which understands how to differentiate updates using the "action" property.

Events which fire:
* Game start - "game_start"
* Game stop - "game_stop"

The following events all have "user" and "team" properties to indicate who caused the event:
* Flag capture - "capture_flag" - includes flag name, value, and scored value
* Flag attempt failure - "capture_failed" - includes flag name and value
* Box complete - "box_complete" - includes box name, reward, type, and difficulty
* Level complete - "level_complete" - includes level name, number, type, and reward