### PR TITLE
add version to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "3"
 services:
   memcached:
     image: memcached:latest


### PR DESCRIPTION
It fixes "Unsupported config option for services service: 'memcached'"
https://docs.docker.com/compose/compose-file/compose-versioning/
That on some system can appear.