### PR TITLE
Add organizer help info on users home page

### DIFF
--- a/locale/de.csv
+++ b/locale/de.csv
@@ -321,6 +321,7 @@ How should the next level unlock?,Wie soll das nächste Level freigeschaltet wer
 I accept the,Ich akzeptiere die 
 "If the flag selection is left empty, the hint will be considered a Box Hint.","Wenn die Flaggen-Auswahl leer gelassen wird, wird der Hinweis berücksichtigt"
 "If this option is disabled, there is no cost for submitting incorrect flags.","Wenn diese Option deaktiviert ist, fallen keine Kosten für die Übermittlung falscher Flaggen an."
+If you have any questions or need help do not hestitate to ask one of the organizers., Wenn Sie Fragen oder Probleme haben zögern Sie nicht sich an einen der Organisatoren zu wenden.
 Import File,Datei importieren
 Import XML,XML importieren
 Import XML,XML importieren

--- a/rootthebox.py
+++ b/rootthebox.py
@@ -491,6 +491,14 @@ define(
     help="links to add to the tool menu",
 )
 
+define(
+    "show_organizor_help",
+    default=False,
+    group="game",
+    help="show an info text on the user's home page about organizor help",
+    type=bool,
+)
+
 # Azure AD
 define("client_id", default="", group="azuread")
 define("tenant_id", default="common", group="azuread")

--- a/rootthebox.py
+++ b/rootthebox.py
@@ -494,7 +494,7 @@ define(
 define(
     "show_organizor_help",
     default=False,
-    group="game",
+    group="application",
     help="show an info text on the user's home page about organizor help",
     type=bool,
 )

--- a/templates/user/home.html
+++ b/templates/user/home.html
@@ -131,6 +131,17 @@
                     </div>
                 </div>
                 <br/>
+				{% if options.show_organizor_help %}
+				<div class="row">
+                    <div class="span1 offset1" style="text-align: center; padding-top: 5px;">
+                        <i class="fa fa-question-circle" style="font-size: 180%;"></i>
+                    </div>
+                    <div class="span7 msgdescription">
+							{{ _("If you have any questions or need help do not hestitate to ask one of the organizers.") }}
+                    </div>
+                </div>
+				<br/>
+				{% end %}
                 <div class="row">
                     <div class="span1 offset1" style="text-align: center; padding-top: 5px;">
                         <i class="fa fa-crosshairs" style="font-size: 180%;"></i>


### PR DESCRIPTION
We held a CTF for a small local group so wanted to inforamtion the users to not hestitate aksing one of teh organizers. This may be helpful for others too.

* Adds a new section to the user home game information panel about asking organizers for help.
* Displaying is also configurable.