### PR TITLE
Import export updates

### DIFF
--- a/handlers/AdminHandlers/AdminGameHandlers.py
+++ b/handlers/AdminHandlers/AdminGameHandlers.py
@@ -600,7 +600,7 @@ class AdminExportHandler(BaseHandler):
         """
         levels_elem = ET.SubElement(root, "gamelevels")
         levels_elem.set("count", "%s" % str(GameLevel.count()))
-        for level in GameLevel.all()[1:]:
+        for level in GameLevel.all():
             level.to_xml(levels_elem)
         category_elem = ET.SubElement(root, "categories")
         category_elem.set("count", "%s" % str(Category.count()))

--- a/handlers/AdminHandlers/AdminGameObjectHandlers.py
+++ b/handlers/AdminHandlers/AdminGameObjectHandlers.py
@@ -1164,15 +1164,16 @@ class AdminDeleteHandler(BaseHandler):
                 self.del_box(box)
             game_levels = sorted(GameLevel.all())
             game_levels.remove(game_level)
+            self.dbsession.delete(game_level)
             for index, level in enumerate(game_levels[:-1]):
                 level.next_level_id = game_levels[index + 1].id
                 self.dbsession.add(level)
-            if game_levels[0].number != 0:
-                game_levels[0].number = 0
-            self.dbsession.add(game_levels[0])
-            game_levels[-1].next_level_id = None
-            self.dbsession.add(game_levels[-1])
-            self.dbsession.delete(game_level)
+            if len(game_levels):
+                if game_levels[0].number != 0:
+                    game_levels[0].number = 0
+                self.dbsession.add(game_levels[0])
+                game_levels[-1].next_level_id = None
+                self.dbsession.add(game_levels[-1])            
             self.dbsession.commit()
             self.redirect("/admin/view/game_levels")
         else:

--- a/models/Box.py
+++ b/models/Box.py
@@ -410,6 +410,7 @@ class Box(DatabaseObject):
         box_elem = ET.SubElement(parent, "box")
         box_elem.set("gamelevel", "%s" % str(self.game_level.number))
         ET.SubElement(box_elem, "name").text = self.name
+        ET.SubElement(box_elem, "order").text = self._order
         ET.SubElement(box_elem, "gamelevel").text = str(self.game_level.number)
         ET.SubElement(box_elem, "operatingsystem").text = self._operating_system
         ET.SubElement(box_elem, "description").text = self._description

--- a/models/Box.py
+++ b/models/Box.py
@@ -411,6 +411,7 @@ class Box(DatabaseObject):
         box_elem.set("gamelevel", "%s" % str(self.game_level.number))
         ET.SubElement(box_elem, "name").text = self.name
         ET.SubElement(box_elem, "order").text = self._order
+        ET.SubElement(box_elem, "order").text = str(self._order)
         ET.SubElement(box_elem, "gamelevel").text = str(self.game_level.number)
         ET.SubElement(box_elem, "operatingsystem").text = self._operating_system
         ET.SubElement(box_elem, "description").text = self._description

--- a/models/GameLevel.py
+++ b/models/GameLevel.py
@@ -203,8 +203,15 @@ class GameLevel(DatabaseObject):
     def to_xml(self, parent):
         level_elem = ET.SubElement(parent, "gamelevel")
         ET.SubElement(level_elem, "number").text = str(self.number)
-        ET.SubElement(level_elem, "buyout").text = str(self.buyout)
         ET.SubElement(level_elem, "type").text = str(self._type)
+        if str(self._type) == "level":
+            buyoutlevel = GameLevel.by_id(self.buyout)
+            if buyoutlevel:
+                ET.SubElement(level_elem, "buyout").text = str(buyoutlevel.number)
+            else:
+                ET.SubElement(level_elem, "buyout").text = "0"
+        else:
+            ET.SubElement(level_elem, "buyout").text = str(self.buyout)
         ET.SubElement(level_elem, "reward").text = str(self._reward)
         ET.SubElement(level_elem, "name").text = str(self._name)
         ET.SubElement(level_elem, "description").text = str(self._description)

--- a/setup/xmlsetup.py
+++ b/setup/xmlsetup.py
@@ -246,11 +246,12 @@ def create_boxes(parent, corporation):
                 box.value = get_child_text(box_elem, "value", "0")
                 box_order = get_child_text(box_elem, "order", None)
                 if box_order:
-                    box.order = box_order
+                    box._order = int(box_order)
                 if get_child_text(box_elem, "avatar", "none") != "none":
-                    box.avatar = bytearray(
+                    avatar_path = get_child_text(box_elem, "avatar_path", "upload")
+                    box.avatar = (bytearray(
                         b64decode(get_child_text(box_elem, "avatar"))
-                    )
+                    ), avatar_path)
                 box.garbage = get_child_text(
                     box_elem, "garbage", binascii.hexlify(urandom(16)).decode()
                 )

--- a/setup/xmlsetup.py
+++ b/setup/xmlsetup.py
@@ -231,7 +231,9 @@ def create_boxes(parent, corporation):
                 box.operating_system = get_child_text(box_elem, "operatingsystem")
                 box.locked = get_child_text(box_elem, "locked", 0)
                 box.value = get_child_text(box_elem, "value", "0")
-                box.order = get_child_text(box_elem, "order", None)
+                box_order = get_child_text(box_elem, "order", None)
+                if box_order:
+                    box.order = box_order
                 if get_child_text(box_elem, "avatar", "none") != "none":
                     box.avatar = bytearray(
                         b64decode(get_child_text(box_elem, "avatar"))

--- a/static/js/pages/admin/view/game_levels.js
+++ b/static/js/pages/admin/view/game_levels.js
@@ -66,6 +66,7 @@ function getDetails(obj, uuid) {
             $("#buyout").hide();
             $("#buyoutlvl").show();
             $("#buyoutlabel").text("Completion of Level");
+            $("#buyoutlvl" + ' option[value=' + response["buyout"] + ']').prop('selected',true);
         } else if (type == "buyout") {
             if (response["buyout"] === 0) {
                 type = "none"

--- a/templates/admin/view/game_levels.html
+++ b/templates/admin/view/game_levels.html
@@ -266,7 +266,7 @@
                     {% elif level.type == "level" %}
                         {% for lv in game_levels %}
                             {% if lv.id == level.buyout %}
-                                <i class="fa fa-lock"></i> {{ _("Unlocks after") }} {{ _("completion of Level") }} {{ lv.number }}
+                                <i class="fa fa-lock"></i> {{ _("Unlocks after") }} {{ _("completion of Level") }} {{ lv.number }} - {{ lv.name }}
                             {% end %}
                         {% end %}
                     {% else %}


### PR DESCRIPTION
### Import / Export Fixes
  - Export the box order (was in import code, but not in export)
  - Export all game levels (including 0)
  - Export level buyout as the level number instead of id (otherwise on import references are incorrect)
  - Import Game Level description (was in export code, but not in import)

### Export New
  - Box: Add `avatar_path` element
    - Support use case where box images may be stored in a path other than `/upload/` (for example in a docker image). Allows export/import to utilize these and not lose the references during import.
    - If the box avatar path does not include `/upload/`, the `avatar_path` will be added to the export xml, otherwise it isn't added.

### Import New
  - Add `import_options` element
    - Options to clear (drop all) levels and corporations during import allowing for overwriting of existing data
    - Element attributes:
      - `clear_levels` - Set to "1" to delete all levels before import starts
      - `clear_corps` - Set to "1" to delete all corporations before import starts
      - Ex `<import_options clear_levels="1" clear_corps="1" />`
  - Pass tuple to box.avatar during import for new `avatar_path` support

#### Box - avatar setter change
  -  Check if value provided is a tuple, and if so set `avatar_path` from second value
    - If `avatar_path` is `upload` - handle like previously to create image based on box.uuid
    - Otherwise use `avatar_path` as-is for image path, the assumption is this will only be from xml imports

### View
  - Game levels view: For level buyouts, added level name in addition to level number to make it clearer
  - Game levels edit: Fix for level buyouts, set selected item in the list properly when opening for edit

### Other
  - Game level deletion fix