### PR TITLE
585 flagdepends

### DIFF
--- a/static/js/pages/admin/view/game_objects.js
+++ b/static/js/pages/admin/view/game_objects.js
@@ -114,22 +114,25 @@ function setFlagType(flagtype) {
 }
 
 function getBoxFlags(box_uuid, flag_uuid) {
-    data = {'uuid': box_uuid, 'obj': 'box', '_xsrf': getCookie("_xsrf")}
-    $.post('/admin/ajax/objects', data, function(response) { 
-        $('#edit-flag-lock').empty();
-        $('#edit-flag-lock').append($('<option/>', { 
-            value: "",
-            text : ""
-        }));
-        $.each(response["flaglist"], function(uuid, name) {    
-            if (uuid !== flag_uuid) {
-                $('#edit-flag-lock').append($('<option/>', { 
-                    value: uuid,
-                    text : name
-                }));
-            } 
-        });
-    }, 'json');
+    return new Promise((resolve, reject) => {
+        let data = {'uuid': box_uuid, 'obj': 'box', '_xsrf': getCookie("_xsrf")};
+        $.post('/admin/ajax/objects', data, function(response) { 
+            $('#edit-flag-lock').empty();
+            $('#edit-flag-lock').append($('<option/>', { 
+                value: "",
+                text : ""
+            }));
+            $.each(response["flaglist"], function(uuid, name) {    
+                if (uuid !== flag_uuid) {
+                    $('#edit-flag-lock').append($('<option/>', { 
+                        value: uuid,
+                        text : name
+                    }));
+                } 
+            });
+            resolve();
+        }, 'json').fail(reject);
+    });
 }
 
 function testToken() {
@@ -253,8 +256,8 @@ $(document).ready(function() {
     });
 
     /* Flag */
-    $("a[id^=edit-flag-button]").click(function() {
-        getBoxFlags($(this).data("box-uuid"), $(this).data("uuid"));
+    $("a[id^=edit-flag-button]").click(async function() {
+        await getBoxFlags($(this).data("box-uuid"), $(this).data("uuid"));
         getDetails("flag", $(this).data("uuid"));
         setFlagType($(this).data("flagtype"));
         $("#test-token").val("");

--- a/templates/admin/create/flag.html
+++ b/templates/admin/create/flag.html
@@ -10,23 +10,23 @@
         {{_("Create Flag")}}
     </h1>
     <br />
-    <a class="btn" data-toggle="modal" href="/admin/create/flag/static{{thebox}}">
+    <a class="btn" href="/admin/create/flag/static{{thebox}}">
         <i class="fa fa-flag-o"></i>
         {{_("Create Static Flag")}} &raquo;
     </a>
-    <a class="btn" data-toggle="modal" href="/admin/create/flag/datetime{{thebox}}">
+    <a class="btn" href="/admin/create/flag/datetime{{thebox}}">
         <i class="fa fa-flag-o"></i>
         {{_("Create Datetime Flag")}} &raquo;
     </a>
-    <a class="btn" data-toggle="modal" href="/admin/create/flag/regex{{thebox}}">
+    <a class="btn" href="/admin/create/flag/regex{{thebox}}">
         <i class="fa fa-flag-o"></i>
         {{_("Create Regex Flag")}} &raquo;
     </a>
-    <a class="btn" data-toggle="modal" href="/admin/create/flag/file{{thebox}}">
+    <a class="btn" href="/admin/create/flag/file{{thebox}}">
         <i class="fa fa-flag-o"></i>
         {{_("Create File Flag")}} &raquo;
     </a>
-    <a class="btn" data-toggle="modal" href="/admin/create/flag/choice{{thebox}}">
+    <a class="btn" href="/admin/create/flag/choice{{thebox}}">
         <i class="fa fa-flag-o"></i>
         {{_("Create Multiple Choice Flag")}} &raquo;
     </a>

--- a/templates/admin/view/game_objects.html
+++ b/templates/admin/view/game_objects.html
@@ -843,7 +843,7 @@
                                             <i class="fa fa-flag-o"></i>
                                             {{_("Flags on") }} {{ box.name }}&nbsp;&nbsp;&nbsp;
                                         </h4>
-                                        <a class="btn btn-primary btn-mini" data-toggle="modal" href="/admin/create/flag?box={{box.uuid}}">
+                                        <a class="btn btn-primary btn-mini" href="/admin/create/flag?box={{box.uuid}}">
                                             <i class="fa fa-plus"></i>
                                             {{_("Add Flags") }}
                                         </a>


### PR DESCRIPTION
Closes #585 

The cause of this bug was a race condition as both getBoxFlags and getDetails were executed at once.  In some cases the flag details would return before the boxflags returned and updated the flaglist, resulting in it selecting the empty option.

This fix makes getBoxFlags return a promise which we now await before moving to getDetails.

---
- Also noticed a jquery error when creating flags from a box link. As the create flag views aren't modals, removed `data-toggle="modal"` for these button links to fix.
