### PR TITLE
validate image size

### DIFF
--- a/libs/XSSImageCheck.py
+++ b/libs/XSSImageCheck.py
@@ -27,7 +27,7 @@ from libs.ValidationError import ValidationError
 MAX_AVATAR_SIZE = 1024 * 1024
 MIN_AVATAR_SIZE = 64
 IMG_FORMATS = ["png", "jpeg", "jpg", "gif", "bmp"]
-
+IMG_SIZE = [500, 250]
 
 def is_xss_image(data):
     # str(char) works here for both py2 & py3
@@ -95,6 +95,13 @@ def existing_avatars(dir):
                 avatars.append(user.avatar)
     return avatars
 
+def verify_image_size(image_data):
+    image = Image.open(io.BytesIO(image_data))
+    if image.width < IMG_SIZE[0] or image.height < IMG_SIZE[1]:
+        raise ValidationError(
+            "Image is too small, minimum size %d x %d"
+            % (IMG_SIZE[0], IMG_SIZE[1])
+        )
 
 def avatar_validation(image_data) -> str:
     """Avatar validation check
@@ -104,6 +111,7 @@ def avatar_validation(image_data) -> str:
     if MIN_AVATAR_SIZE < len(image_data) < MAX_AVATAR_SIZE:
         ext = imghdr.what("", h=image_data)
         if ext in IMG_FORMATS and not is_xss_image(image_data):
+            verify_image_size(image_data)                                
             return ext
         else:
             raise ValidationError(
@@ -131,7 +139,7 @@ def save_avatar(path: str, image_data: bytes) -> str:
             os.unlink(image_path)
             
         image = Image.open(io.BytesIO(image_data))
-        cover = resizeimage.resize_cover(image, [500, 250])
+        cover = resizeimage.resize_cover(image, IMG_SIZE)
         cover.save(image_path, image.format)
         return str(base_path)
         


### PR DESCRIPTION
Fixes an issue where users might upload an image under the minimum dimensions (500x250) during registration. This would leave their user account in an unusable state, and completely unmanageable even from the UI as an admin.

This fix validates the image size as part of the validation check, raising a validation error if the image dimensions are too small.